### PR TITLE
Fix issue MixinNetwork/flutter-plugins#51

### DIFF
--- a/packages/desktop_drop/lib/desktop_drop_web.dart
+++ b/packages/desktop_drop/lib/desktop_drop_web.dart
@@ -38,15 +38,19 @@ class DesktopDropWeb {
       try {
         final items = event.dataTransfer.files;
         if (items != null) {
-          for (var index = 0; index < items.length; index++) {
-            results.add(WebDropItem(
-              uri: html.Url.createObjectUrl(items[index]),
-              name: items[index].name,
-              size: items[index].size,
-              type: items[index].type,
-              relativePath: items[index].relativePath,
-              lastModified: items[index].lastModifiedDate,
-            ));
+          for (final item in items) {
+            results.add(
+              WebDropItem(
+                uri: html.Url.createObjectUrl(item),
+                name: item.name,
+                size: item.size,
+                type: item.type,
+                relativePath: item.relativePath,
+                lastModified: item.lastModified != null
+                    ? DateTime.fromMillisecondsSinceEpoch(item.lastModified!)
+                    : item.lastModifiedDate,
+              ),
+            );
           }
         }
       } catch (e, s) {


### PR DESCRIPTION
fixes #51 by accessing item.lastModified in favor of item.lastModifiedDate, when available. This mitigates a crash in Safari.