### PR TITLE
refactor performDragOperation on macOS

### DIFF
--- a/packages/desktop_drop/CHANGELOG.md
+++ b/packages/desktop_drop/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.3.3
+
+* Fix dragging multiple files at once from Apple Music does not work well. [#72](https://github.com/MixinNetwork/flutter-plugins/issues/72)
+
 ## 0.3.2
 
-* Fix non ascii characters path on linux. (#53)[https://github.com/MixinNetwork/flutter-plugins/issues/53]
+* Fix non ascii characters path on linux. [#53](https://github.com/MixinNetwork/flutter-plugins/issues/53)
 
 ## 0.3.1
 

--- a/packages/desktop_drop/example/pubspec.lock
+++ b/packages/desktop_drop/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.1"
+    version: "0.3.2"
   fake_async:
     dependency: transitive
     description:
@@ -120,7 +120,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -146,7 +146,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -182,20 +182,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
   dart: ">=2.16.0-100.0.dev <3.0.0"
   flutter: ">=1.22.0"

--- a/packages/desktop_drop/example/windows/flutter/generated_plugins.cmake
+++ b/packages/desktop_drop/example/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -14,3 +17,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/packages/desktop_drop/pubspec.yaml
+++ b/packages/desktop_drop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_drop
 description: A plugin which allows user dragging files to your flutter desktop applications.
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_drop
 
 environment:


### PR DESCRIPTION
fix #72

use `draggingPasteboard.readObjects` instead `NSDraggingInfo.enumerateDraggingItems` to retrieve `NSURL` form drag info.