### PR TITLE
HTML Clipboard Format support

### DIFF
--- a/packages/pasteboard/example/pubspec.lock
+++ b/packages/pasteboard/example/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,7 +87,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -101,14 +101,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -155,14 +155,21 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/pasteboard/example/windows/flutter/generated_plugins.cmake
+++ b/packages/pasteboard/example/windows/flutter/generated_plugins.cmake
@@ -6,9 +6,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   pasteboard
 )
 
-list(APPEND FLUTTER_FFI_PLUGIN_LIST
-)
-
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -17,8 +14,3 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
-
-foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
-  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
-  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
-endforeach(ffi_plugin)

--- a/packages/pasteboard/lib/pasteboard.dart
+++ b/packages/pasteboard/lib/pasteboard.dart
@@ -32,7 +32,7 @@ class Pasteboard {
   ///
   static Future<String?> get html async {
     if (Platform.isWindows) {
-      return await _channel.invokeMethod<Object>('html') as String;
+      return await _channel.invokeMethod<Object>('html') as String?;
     }
     return null;
   }

--- a/packages/pasteboard/lib/pasteboard.dart
+++ b/packages/pasteboard/lib/pasteboard.dart
@@ -26,6 +26,17 @@ class Pasteboard {
     return null;
   }
 
+  /// only available on Windows
+  /// Get "HTML format" from system pasteboard.
+  ///  HTML format: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa767917(v=vs.85)
+  ///
+  static Future<String?> get html async {
+    if (Platform.isWindows) {
+      return await _channel.invokeMethod<Object>('html') as String;
+    }
+    return null;
+  }
+
   /// only available on iOS
   ///
   /// set image data to system pasteboard.

--- a/packages/pasteboard/windows/pasteboard_plugin.cpp
+++ b/packages/pasteboard/windows/pasteboard_plugin.cpp
@@ -430,7 +430,36 @@ void PasteboardPlugin::HandleMethodCall(
     }
     SetClipboardData(CF_HDROP, storage.hGlobal);
     result->Success();
-  } else {
+  } else if (method_call.method_name() == "html"){
+    
+    #define CF_HTML 49380
+
+    if (!IsClipboardFormatAvailable(CF_HTML)) {
+      result->Success();
+      return;
+    }
+
+    if (!OpenClipboard(nullptr)) {
+      result->Error("0", "open clipboard failed");
+      return;
+    }
+
+			HANDLE t = GetClipboardData(CF_HTML);
+			if (t == NULL) {
+				result->Success();
+        return;
+			}
+			else {				
+					char* p = (char*)GlobalLock(t);
+					SIZE_T size = GlobalSize(t);
+					std::string str;
+					str.assign(p, size);
+					result->Success(flutter::EncodableValue(str));
+					GlobalUnlock(t);
+				}		
+		CloseClipboard();
+
+  }  else {
     result->NotImplemented();
   }
 }

--- a/packages/pasteboard/windows/pasteboard_plugin.cpp
+++ b/packages/pasteboard/windows/pasteboard_plugin.cpp
@@ -439,28 +439,28 @@ void PasteboardPlugin::HandleMethodCall(
       return;
     }
 
-    if (!OpenClipboard(nullptr)) {
-      result->Error("0", "open clipboard failed");
-      return;
-    }
-
-			HANDLE t = GetClipboardData(CF_HTML);
-			if (t == NULL) {
-				result->Success();
-        return;
-			}
-			else {				
-					char* p = (char*)GlobalLock(t);
-					SIZE_T size = GlobalSize(t);
-					std::string str;
-					str.assign(p, size);
-					result->Success(flutter::EncodableValue(str));
-					GlobalUnlock(t);
-				}		
+	if (!OpenClipboard(nullptr)) {
+		result->Error("0", "open clipboard failed");
+		return;
+	}
+	HANDLE hClipboardData = GetClipboardData(CF_HTML);
+	if (hClipboardData == NULL) {
+		result->Success();
 		CloseClipboard();
-
-  }  else {
-    result->NotImplemented();
+		return;
+	}
+	else {
+		char* p = (char*)GlobalLock(hClipboardData);
+		SIZE_T size = GlobalSize(hClipboardData);
+		std::string str;
+		str.assign(p, size);
+		result->Success(flutter::EncodableValue(str));
+		GlobalUnlock(hClipboardData);
+	}
+	CloseClipboard();
+  }
+  else {
+  result->NotImplemented();
   }
 }
 


### PR DESCRIPTION
A new property "html" to retrieve from the clipboard the html text from CF_HTML (49380) field.
The HTML Clipboard Format description: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa767917(v=vs.85)

I didn't change the pubspec.lock and generated_plugins.cmake files, don't know why there are some changes.