### PR TITLE
fix js version dependence

### DIFF
--- a/packages/pasteboard/pubspec.yaml
+++ b/packages/pasteboard/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.6.4
+  js: ^0.6.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes the problem, described in this issue - https://github.com/MixinNetwork/flutter-plugins/issues/121