### PR TITLE
[desktop_multi_window] Added the `resizable` function (macOS only)

### DIFF
--- a/packages/desktop_multi_window/CHANGELOG.md
+++ b/packages/desktop_multi_window/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+* Added the ability to determine whether a created window will be resizable or not
+([#101](https://github.com/MixinNetwork/flutter-plugins/issues/101) and [#130](https://github.com/MixinNetwork/flutter-plugins/pull/130))
+
 ## 0.1.0
 
 * [BREAK CHANGE] upgrade min flutter version to 3.0.0

--- a/packages/desktop_multi_window/example/lib/main.dart
+++ b/packages/desktop_multi_window/example/lib/main.dart
@@ -51,6 +51,7 @@ class _ExampleMainWindowState extends State<_ExampleMainWindow> {
                   ..setFrame(const Offset(0, 0) & const Size(1280, 720))
                   ..center()
                   ..setTitle('Another window')
+                  ..resizable(false)
                   ..show();
               },
               child: const Text('Create a new World!'),

--- a/packages/desktop_multi_window/example/lib/main.dart
+++ b/packages/desktop_multi_window/example/lib/main.dart
@@ -45,7 +45,7 @@ class _ExampleMainWindowState extends State<_ExampleMainWindow> {
                   'args1': 'Sub window',
                   'args2': 100,
                   'args3': true,
-                  'bussiness': 'bussiness_test',
+                  'business': 'business_test',
                 }));
                 window
                   ..setFrame(const Offset(0, 0) & const Size(1280, 720))

--- a/packages/desktop_multi_window/example/pubspec.lock
+++ b/packages/desktop_multi_window/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/desktop_multi_window/example/pubspec.lock
+++ b/packages/desktop_multi_window/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.1.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/desktop_multi_window/lib/desktop_multi_window.dart
+++ b/packages/desktop_multi_window/lib/desktop_multi_window.dart
@@ -27,7 +27,7 @@ class DesktopMultiWindow {
   /// NOTE: [createWindow] will only create a new window, you need to call
   /// [WindowController.show] to show the window.
   static Future<WindowController> createWindow([String? arguments]) async {
-    final windowId = await miltiWindowChannel.invokeMethod<int>(
+    final windowId = await multiWindowChannel.invokeMethod<int>(
       'createWindow',
       arguments,
     );
@@ -73,7 +73,7 @@ class DesktopMultiWindow {
 
   /// Get all sub window id.
   static Future<List<int>> getAllSubWindowIds() async {
-    final result = await miltiWindowChannel
+    final result = await multiWindowChannel
         .invokeMethod<List<dynamic>>('getAllSubWindowIds');
     final ids = result?.cast<int>() ?? const [];
     assert(!ids.contains(0), 'ids must not contains main window id');

--- a/packages/desktop_multi_window/lib/src/channels.dart
+++ b/packages/desktop_multi_window/lib/src/channels.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/services.dart';
 
-const miltiWindowChannel = MethodChannel('mixin.one/flutter_multi_window');
+const multiWindowChannel = MethodChannel('mixin.one/flutter_multi_window');
 
 const windowEventChannel = MethodChannel(
   'mixin.one/flutter_multi_window_channel',

--- a/packages/desktop_multi_window/lib/src/window_controller.dart
+++ b/packages/desktop_multi_window/lib/src/window_controller.dart
@@ -37,8 +37,12 @@ abstract class WindowController {
   Future<void> setTitle(String title);
 
   /// Whether the window can be resized.
+  ///
+  /// Most useful for ensuring windows *cannot* be resized. Windows are
+  /// resizable by default, so there is no need to explicitly define a window
+  /// as resizable by calling this function.
   Future<void> resizable(bool resizable);
 
-  /// available only on macOS.
+  /// Available only on macOS.
   Future<void> setFrameAutosaveName(String name);
 }

--- a/packages/desktop_multi_window/lib/src/window_controller.dart
+++ b/packages/desktop_multi_window/lib/src/window_controller.dart
@@ -36,7 +36,7 @@ abstract class WindowController {
   /// Set the window's title.
   Future<void> setTitle(String title);
 
-  /// Whether the window can be resized.
+  /// Whether the window can be resized. Available only on macOS.
   ///
   /// Most useful for ensuring windows *cannot* be resized. Windows are
   /// resizable by default, so there is no need to explicitly define a window

--- a/packages/desktop_multi_window/lib/src/window_controller.dart
+++ b/packages/desktop_multi_window/lib/src/window_controller.dart
@@ -36,6 +36,9 @@ abstract class WindowController {
   /// Set the window's title.
   Future<void> setTitle(String title);
 
+  /// Whether the window can be resized.
+  Future<void> resizable(bool resizable);
+
   /// available only on macOS.
   Future<void> setFrameAutosaveName(String name);
 }

--- a/packages/desktop_multi_window/lib/src/window_controller_impl.dart
+++ b/packages/desktop_multi_window/lib/src/window_controller_impl.dart
@@ -6,7 +6,7 @@ import 'channels.dart';
 import 'window_controller.dart';
 
 class WindowControllerMainImpl extends WindowController {
-  final MethodChannel _channel = miltiWindowChannel;
+  final MethodChannel _channel = multiWindowChannel;
 
   // the id of this window
   final int _id;
@@ -52,6 +52,14 @@ class WindowControllerMainImpl extends WindowController {
     return _channel.invokeMethod('setTitle', <String, dynamic>{
       'windowId': _id,
       'title': title,
+    });
+  }
+
+  @override
+  Future<void> resizable(bool resizable) {
+    return _channel.invokeMethod('resizable', <String, dynamic>{
+      'windowId': _id,
+      'resizable': resizable,
     });
   }
 

--- a/packages/desktop_multi_window/lib/src/window_controller_impl.dart
+++ b/packages/desktop_multi_window/lib/src/window_controller_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
@@ -57,10 +58,16 @@ class WindowControllerMainImpl extends WindowController {
 
   @override
   Future<void> resizable(bool resizable) {
-    return _channel.invokeMethod('resizable', <String, dynamic>{
-      'windowId': _id,
-      'resizable': resizable,
-    });
+    if (Platform.isMacOS) {
+      return _channel.invokeMethod('resizable', <String, dynamic>{
+        'windowId': _id,
+        'resizable': resizable,
+      });
+    } else {
+      throw MissingPluginException(
+        'This functionality is only available on macOS',
+      );
+    }
   }
 
   @override

--- a/packages/desktop_multi_window/macos/Classes/FlutterMultiWindowPlugin.swift
+++ b/packages/desktop_multi_window/macos/Classes/FlutterMultiWindowPlugin.swift
@@ -67,6 +67,12 @@ public class FlutterMultiWindowPlugin: NSObject, FlutterPlugin {
       let title = arguments["title"] as! String
       MultiWindowManager.shared.setTitle(windowId: windowId, title: title)
       result(nil)
+	case "resizable":
+	  let arguments = call.arguments as! [String: Any?]
+	  let windowId = arguments["windowId"] as! Int64
+	  let resizable = arguments["resizable"] as! Bool
+	  MultiWindowManager.shared.resizable(windowId: windowId, resizable: resizable)
+	  result(nil)
     case "setFrameAutosaveName":
       let arguments = call.arguments as! [String: Any?]
       let windowId = arguments["windowId"] as! Int64

--- a/packages/desktop_multi_window/macos/Classes/FlutterWindow.swift
+++ b/packages/desktop_multi_window/macos/Classes/FlutterWindow.swift
@@ -39,6 +39,14 @@ class BaseFlutterWindow: NSObject {
     window.title = title
   }
 
+  func resizable(resizable: Bool) {
+    if (resizable) {
+      window.styleMask.remove(.resizable)
+    } else {
+      window.styleMask.insert(.resizable)
+    }
+  }
+
   func close() {
     window.close()
   }

--- a/packages/desktop_multi_window/macos/Classes/FlutterWindow.swift
+++ b/packages/desktop_multi_window/macos/Classes/FlutterWindow.swift
@@ -41,9 +41,9 @@ class BaseFlutterWindow: NSObject {
 
   func resizable(resizable: Bool) {
     if (resizable) {
-      window.styleMask.remove(.resizable)
-    } else {
       window.styleMask.insert(.resizable)
+    } else {
+      window.styleMask.remove(.resizable)
     }
   }
 

--- a/packages/desktop_multi_window/macos/Classes/MultiWindowManager.swift
+++ b/packages/desktop_multi_window/macos/Classes/MultiWindowManager.swift
@@ -94,6 +94,14 @@ class MultiWindowManager {
     window.setTitle(title: title)
   }
 
+  func resizable(windowId: Int64, resizable: Bool) {
+    guard let window = windows[windowId] else {
+      debugPrint("window \(windowId) not exists.")
+      return
+    }
+    window.resizable(resizable: resizable)
+  }
+
   func setFrameAutosaveName(windowId: Int64, name: String) {
     guard let window = windows[windowId] else {
       debugPrint("window \(windowId) not exists.")

--- a/packages/desktop_multi_window/pubspec.yaml
+++ b/packages/desktop_multi_window/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_multi_window
 description: A flutter plugin that create and manager multi window in desktop.
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_multi_window
 
 environment:


### PR DESCRIPTION
This PR adds the ability to control whether a created window can be resized or not by calling the `resizable()` function. Passing `false` to the function will result in a window that cannot be resized. 

There is no need to explicitly set a window to be resizable - windows will be resizable by default.

Here is an example of a non-resizable window:
```dart
final window = await DesktopMultiWindow.createWindow(jsonEncode({
  'args1': 'Sub window',
  'args2': 100,
  'args3': true,
  'business': 'business_test',
}));

window
  ..setFrame(const Offset(0, 0) & const Size(1280, 720))
  ..center()
  ..setTitle('Another window')
  ..resizable(false)
  ..show();
```
Removing the `..resizable(false)` call will result in a window that *is* resizable.

***Please note*** that this feature has only been implemented for macOS. The documentation reflects this, and a platform check has been implemented to ensure developers do not try to use it on other platforms. (The docs and check can of course be updated in the future if the feature is implemented on Windows and Linux.)

Closes #101 