### PR TITLE
[mixin-logger] make initLogger return Future<void> instead of void

### DIFF
--- a/packages/mixin_logger/README.md
+++ b/packages/mixin_logger/README.md
@@ -22,12 +22,21 @@ void main() {
 ```dart
 void main() {
   // init logger with dir. then all logs will be saved to this dir.
-  initLogger(
-    'app_log_files_dir',
+  await initLogger(
+    '/tmp/app_log_files_dir',
     maxFileCount: 10, // max 10 files.
     maxFileLength: 5 * 1024 * 1024, // max to 5 MB for single file.
   );
+  i('after initLogger');
 }
+```
+
+The folder is created automatically:
+``` 
+pwd
+/tmp/app_log_files_dir
+cat log_0.log
+2022-08-26 12:41:00.623 [I] after initLogger
 ```
 
 ## License

--- a/packages/mixin_logger/lib/mixin_logger.dart
+++ b/packages/mixin_logger/lib/mixin_logger.dart
@@ -64,14 +64,14 @@ extension _LogLevelExtension on _LogLevel {
   }
 }
 
-void initLogger(
+Future<void> initLogger(
   String logDir, {
   int maxFileCount = 10,
   int maxFileLength = 1024 * 1024 * 10, // 10 MB
-}) {
+}) async {
   assert(maxFileCount > 1, 'maxFileCount must be greater than 1');
   assert(maxFileLength > 10 * 1024, 'maxFileLength must be greater than 10 KB');
-  platform.initLogger(logDir, maxFileCount, maxFileLength);
+  await platform.initLogger(logDir, maxFileCount, maxFileLength);
 }
 
 void v(String message) {

--- a/packages/mixin_logger/lib/src/write_log_to_file_io.dart
+++ b/packages/mixin_logger/lib/src/write_log_to_file_io.dart
@@ -8,10 +8,10 @@ void writeLog(String log) {
   LogFileManager.instance?.write(log);
 }
 
-void initLogger(
+Future<void> initLogger(
   String logDir,
   int maxFileCount,
   int maxFileLength,
-) {
-  LogFileManager.init(logDir, maxFileCount, maxFileLength);
+) async {
+  await LogFileManager.init(logDir, maxFileCount, maxFileLength);
 }

--- a/packages/mixin_logger/lib/src/write_log_to_file_web.dart
+++ b/packages/mixin_logger/lib/src/write_log_to_file_web.dart
@@ -4,8 +4,8 @@ void writeLog(String log) {
   // do nothing.
 }
 
-void initLogger(
+Future<void> initLogger(
   String logDir,
   int maxFileCount,
   int maxFileLength,
-) {}
+) async {}

--- a/packages/mixin_logger/test/mixin_logger_test.dart
+++ b/packages/mixin_logger/test/mixin_logger_test.dart
@@ -117,6 +117,7 @@ void main() {
     expect(fileContent, equals('test\n'));
   });
 
+
   test('test write on other isolate', () async {
     await LogFileManager.init(dir, 10, 1024 * 1024 * 10);
     final manger = LogFileManager.instance!;
@@ -128,6 +129,15 @@ void main() {
     final fileContent = File(p.join(dir, 'log_0.log')).readAsStringSync();
     expect(fileContent, equals('main\nother isolate\n'));
   });
+
+  test('test write by initLogger', () async {
+    await initLogger(dir, maxFileCount: 10, maxFileLength: 1024 * 1024 * 10);
+    i('after initLogger');
+    expect(FileSystemEntity.isFileSync(p.join(dir, 'log_0.log')), isTrue);
+    final fileContent = File(p.join(dir, 'log_0.log')).readAsStringSync();
+    expect(fileContent, contains('after initLogger\n'));
+  });
+
 }
 
 void _writeLog(String message) {


### PR DESCRIPTION
If initLogger is not awaited the following log messages using f.e.  i() are not written.

LogFileManager.init() is already returning a Future, but initLogger doesn't await on it.

That's changed now.