### PR TITLE
[desktop_drop] Fix broken gestures when used with modified MainFlutterWindow

### DIFF
--- a/packages/desktop_drop/macos/Classes/DesktopDropPlugin.swift
+++ b/packages/desktop_drop/macos/Classes/DesktopDropPlugin.swift
@@ -1,10 +1,26 @@
 import Cocoa
 import FlutterMacOS
 
+private func findFlutterViewController(_ viewController: NSViewController?) -> FlutterViewController? {
+  guard let vc = viewController else {
+    return nil
+  }
+  if let fvc = vc as? FlutterViewController {
+    return fvc
+  }
+  for child in vc.children {
+    let fvc = findFlutterViewController(child)
+    if fvc != nil {
+      return fvc
+    }
+  }
+  return nil
+}
+
 public class DesktopDropPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     guard let app = NSApplication.shared.delegate as? FlutterAppDelegate else { return }
-    guard let vc = app.mainFlutterWindow.contentViewController else { return }
+    guard let vc = findFlutterViewController(app.mainFlutterWindow.contentViewController) else { return }
 
     let channel = FlutterMethodChannel(name: "desktop_drop", binaryMessenger: registrar.messenger)
     let instance = DesktopDropPlugin()


### PR DESCRIPTION
When used in conjunction with plugins that replace the `FlutterViewController` in macOS Flutter apps, such as [`flutter_acrylic`][1] and [`macos_ui`][2], `desktop_drop` causes some trackpad gestures to break. I found that pinch-to-zoom no longer worked, but there could be other weird behavior I missed.

This PR fixes the issue by recursively searching the view controller hierarchy starting at `MainFlutterWindow.contentViewController` for a `FlutterViewController` to attach its child view to.

[1]: https://github.com/alexmercerind/flutter_acrylic/blob/88019e9ed841354d3af02e31c138a133e350a0d6/example/macos/Runner/MainFlutterWindow.swift#L8
[2]: https://github.com/GroovinChip/macos_ui/blob/d6d4a27f3f4c2ad28aeb1c77126cdc6884979736/example/macos/Runner/MainFlutterWindow.swift#L40