### PR TITLE
[desktop_webview_window] Correct API Definition of post webmessages

### DIFF
--- a/packages/desktop_webview_window/lib/src/webview.dart
+++ b/packages/desktop_webview_window/lib/src/webview.dart
@@ -82,8 +82,8 @@ abstract class Webview {
   Future<String?> evaluateJavaScript(String javaScript);
 
   /// post a web message as String to the top level document in this WebView
-  Future<String?> postWebMessageAsString(String webMessage);
+  Future<void> postWebMessageAsString(String webMessage);
 
   /// post a web message as JSON to the top level document in this WebView
-  Future<String?> postWebMessageAsJson(String webMessage);
+  Future<void> postWebMessageAsJson(String webMessage);
 }

--- a/packages/desktop_webview_window/lib/src/webview_impl.dart
+++ b/packages/desktop_webview_window/lib/src/webview_impl.dart
@@ -236,7 +236,7 @@ class WebviewImpl extends Webview {
   }
 
   @override
-  Future<String?> postWebMessageAsString(String webMessage) async {
+  Future<void> postWebMessageAsString(String webMessage) async {
     return channel.invokeMethod("postWebMessageAsString", {
       "viewId": viewId,
       "webMessage": webMessage,
@@ -244,7 +244,7 @@ class WebviewImpl extends Webview {
   }
 
   @override
-  Future<String?> postWebMessageAsJson(String webMessage) async {
+  Future<void> postWebMessageAsJson(String webMessage) async {
     return channel.invokeMethod("postWebMessageAsJson", {
       "viewId": viewId,
       "webMessage": webMessage,

--- a/packages/desktop_webview_window/windows/web_view.cc
+++ b/packages/desktop_webview_window/windows/web_view.cc
@@ -303,7 +303,7 @@ void WebView::PostWebMessageAsString(const std::wstring &webmessage,
       webmessage.c_str()) == NOERROR) {
       completer->Success();
     } else {
-       completer->Error("0", "Error posting webmessage as String");
+      completer->Error("0", "Error posting webmessage as String");
     }
   } else {
     completer->Error("0", "webview not created");


### PR DESCRIPTION
The API definitions for

Future<String?> postWebMessageAsString(String webMessage)
Future<String?> postWebMessageAsJson(String webMessage)

should be

Future<void> postWebMessageAsString(String webMessage)
Future<void> postWebMessageAsJson(String webMessage)