### PR TITLE
fix linux webkit2gtk some function deprecated error

### DIFF
--- a/packages/desktop_webview_window/linux/webview_window.cc
+++ b/packages/desktop_webview_window/linux/webview_window.cc
@@ -216,17 +216,17 @@ gboolean WebviewWindow::DecidePolicy(WebKitPolicyDecision *decision, WebKitPolic
 }
 
 void WebviewWindow::EvaluateJavaScript(const char *java_script, FlMethodCall *call) {
-  webkit_web_view_run_javascript(
-      WEBKIT_WEB_VIEW(webview_), java_script, nullptr,
+  webkit_web_view_evaluate_javascript(
+      WEBKIT_WEB_VIEW(webview_), java_script,-1,nullptr,nullptr, nullptr,
       [](GObject *object, GAsyncResult *result, gpointer user_data) {
         auto *call = static_cast<FlMethodCall *>(user_data);
         GError *error = nullptr;
-        auto *js_result = webkit_web_view_run_javascript_finish(WEBKIT_WEB_VIEW(object), result, &error);
+        auto *js_result = webkit_web_view_evaluate_javascript_finish(WEBKIT_WEB_VIEW(object), result, &error);
         if (!js_result) {
           fl_method_call_respond_error(call, "failed to evaluate javascript.", error->message, nullptr, nullptr);
           g_error_free(error);
         } else {
-          auto *js_value = jsc_value_to_json(webkit_javascript_result_get_js_value(js_result), 0);
+          auto *js_value = jsc_value_to_json(js_result, 0);
           fl_method_call_respond_success(call, js_value ? fl_value_new_string(js_value) : nullptr, nullptr);
         }
         g_object_unref(call);


### PR DESCRIPTION
when I use desktop-webview-window in manjaro, I meet an error:
![image](https://github.com/MixinNetwork/flutter-plugins/assets/34616640/6df929df-fd6c-4303-882d-8dce53cc0065)
