### PR TITLE
[desktop-webview-window] Bring Webview Window to Foreground

### DIFF
--- a/packages/desktop_webview_window/lib/src/webview.dart
+++ b/packages/desktop_webview_window/lib/src/webview.dart
@@ -56,6 +56,9 @@ abstract class Webview {
   /// Show or hide webview window
   Future<void> setWebviewWindowVisibility(bool visible);
 
+  /// Activates the webview window (giving it the focus)
+  Future<void> bringToForeground();
+
   /// Reload the current page.
   Future<void> reload();
 

--- a/packages/desktop_webview_window/lib/src/webview_impl.dart
+++ b/packages/desktop_webview_window/lib/src/webview_impl.dart
@@ -179,6 +179,13 @@ class WebviewImpl extends Webview {
   }
 
   @override
+  Future<void> bringToForeground() {
+    return channel.invokeMethod("bringToForeground", {
+      "viewId": viewId,
+    });
+  }
+
+  @override
   Future<void> back() {
     return channel.invokeMethod("back", {"viewId": viewId});
   }

--- a/packages/desktop_webview_window/windows/web_view_window_plugin.cc
+++ b/packages/desktop_webview_window/windows/web_view_window_plugin.cc
@@ -176,6 +176,19 @@ void WebviewWindowPlugin::HandleMethodCall(
     }
     windows_[window_id]->setVisibility(visible);
     result->Success();
+  } else if (method_call.method_name() == "bringToForeground") {
+    auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    if (!windows_.count(window_id)) {
+      result->Error("0", "can not find webview window for id");
+      return;
+    }
+    if (!windows_[window_id]->GetWebView()) {
+      result->Error("0", "webview window not ready");
+      return;
+    }
+    windows_[window_id]->bringToForeground();
+    result->Success();
   } else if (method_call.method_name() == "reload") {
     auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
     auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();

--- a/packages/desktop_webview_window/windows/webview_window.cc
+++ b/packages/desktop_webview_window/windows/webview_window.cc
@@ -144,6 +144,11 @@ void WebviewWindow::setVisibility(bool visible)
     ::ShowWindow(hwnd_.get(), SW_HIDE);
 }
 
+void WebviewWindow::bringToForeground()
+{
+  SetForegroundWindow(hwnd_.get());
+}
+
 // static
 LRESULT CALLBACK
 WebviewWindow::WndProc(

--- a/packages/desktop_webview_window/windows/webview_window.h
+++ b/packages/desktop_webview_window/windows/webview_window.h
@@ -58,6 +58,8 @@ class WebviewWindow {
 
   void setVisibility(bool visible);
 
+  void bringToForeground();
+
   [[nodiscard]] const std::unique_ptr<webview_window::WebView> &GetWebView() const {
     return web_view_;
   }


### PR DESCRIPTION
This PR adds the functionality to bring the webview window to the foreground under windows