### PR TITLE
[desktop_drop] fix windows build warning C4701

### DIFF
--- a/packages/desktop_drop/windows/desktop_drop_plugin.cpp
+++ b/packages/desktop_drop/windows/desktop_drop_plugin.cpp
@@ -138,9 +138,14 @@ namespace {
                         registrar->messenger(), "desktop_drop",
                         &flutter::StandardMethodCodec::GetInstance());
 
-        HWND hwnd;
+        HWND hwnd = nullptr;
         if (registrar->GetView()) {
             hwnd = registrar->GetView()->GetNativeWindow();
+        }
+
+        if (hwnd == nullptr) {
+            // no window, no drop.
+            return;
         }
 
         channel->SetMethodCallHandler([](const auto &call, auto result) {


### PR DESCRIPTION
close #278 

fix desktop_drop_plugin.cpp(150): warning C4701: potentially uninitialized local variable 'hwnd' used 