### PR TITLE
[desktop-webview-window] Add maximized parameter to bringToForeground()

### DIFF
--- a/packages/desktop_webview_window/lib/src/webview.dart
+++ b/packages/desktop_webview_window/lib/src/webview.dart
@@ -60,7 +60,7 @@ abstract class Webview {
   Future<void> moveWebviewWindow(int left, int top, int width, int height);
 
   /// Activates the webview window (giving it the focus)
-  Future<void> bringToForeground();
+  Future<void> bringToForeground({bool maximized = false});
 
   /// Reload the current page.
   Future<void> reload();

--- a/packages/desktop_webview_window/lib/src/webview_impl.dart
+++ b/packages/desktop_webview_window/lib/src/webview_impl.dart
@@ -190,9 +190,10 @@ class WebviewImpl extends Webview {
   }
 
   @override
-  Future<void> bringToForeground() {
+  Future<void> bringToForeground({bool maximized = false}) {
     return channel.invokeMethod("bringToForeground", {
       "viewId": viewId,
+      "maximized": maximized,
     });
   }
 

--- a/packages/desktop_webview_window/windows/web_view_window_plugin.cc
+++ b/packages/desktop_webview_window/windows/web_view_window_plugin.cc
@@ -196,6 +196,7 @@ void WebviewWindowPlugin::HandleMethodCall(
   } else if (method_call.method_name() == "bringToForeground") {
     auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
     auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto maximized = std::get<bool>(arguments->at(flutter::EncodableValue("maximized")));
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -204,7 +205,7 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "webview window not ready");
       return;
     }
-    windows_[window_id]->bringToForeground();
+    windows_[window_id]->bringToForeground(maximized);
     result->Success();
   } else if (method_call.method_name() == "reload") {
     auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());

--- a/packages/desktop_webview_window/windows/webview_window.cc
+++ b/packages/desktop_webview_window/windows/webview_window.cc
@@ -148,8 +148,11 @@ void WebviewWindow::moveWebviewWindow(int left, int top, int width, int height) 
   ::SetWindowPos(hwnd_.get(), nullptr, left, top, width, height, SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
-void WebviewWindow::bringToForeground() {
+void WebviewWindow::bringToForeground(bool maximized) {
   SetForegroundWindow(hwnd_.get());
+  if (maximized) {
+    ::ShowWindow(hwnd_.get(), SW_MAXIMIZE);
+  }
 }
 
 // static

--- a/packages/desktop_webview_window/windows/webview_window.h
+++ b/packages/desktop_webview_window/windows/webview_window.h
@@ -60,7 +60,7 @@ class WebviewWindow {
 
   void moveWebviewWindow(int left, int top, int width, int height);
 
-  void bringToForeground();
+  void bringToForeground(bool maximized);
 
   [[nodiscard]] const std::unique_ptr<webview_window::WebView> &GetWebView() const {
     return web_view_;


### PR DESCRIPTION
This PR adds a maximized parameter to the bringToForeground function. with maximized:true, the webview window is brought to foreground and maximized at the same time