### PR TITLE
[desktop_drop] Drag and drop folder on web now returns the folder's content

### DIFF
--- a/packages/desktop_drop/.metadata
+++ b/packages/desktop_drop/.metadata
@@ -4,7 +4,39 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: 01e10e793e2459e9e563d5f928e40452aecd80cc
-  channel: master
+  revision: "2524052335ec76bb03e04ede244b071f1b86d190"
+  channel: "stable"
 
 project_type: plugin
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+      base_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+    - platform: android
+      create_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+      base_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+    - platform: linux
+      create_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+      base_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+    - platform: macos
+      create_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+      base_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+    - platform: web
+      create_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+      base_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+    - platform: windows
+      create_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+      base_revision: 2524052335ec76bb03e04ede244b071f1b86d190
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'

--- a/packages/desktop_drop/example/lib/main.dart
+++ b/packages/desktop_drop/example/lib/main.dart
@@ -48,6 +48,20 @@ class _ExampleDragTargetState extends State<ExampleDragTarget> {
 
   Offset? offset;
 
+  Future<void> printFiles(List<DropItem> files, [int depth = 0]) async {
+    debugPrint('  |' * depth);
+    for (final file in files) {
+      debugPrint('  |' * depth +
+          '> ${file.path} ${file.name}'
+              '  ${await file.lastModified()}'
+              '  ${await file.length()}'
+              '  ${file.mimeType}');
+      if (file is DropItemDirectory) {
+        printFiles(file.children, depth + 1);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return DropTarget(
@@ -57,12 +71,7 @@ class _ExampleDragTargetState extends State<ExampleDragTarget> {
         });
 
         debugPrint('onDragDone:');
-        for (final file in detail.files) {
-          debugPrint('  ${file.path} ${file.name}'
-              '  ${await file.lastModified()}'
-              '  ${await file.length()}'
-              '  ${file.mimeType}');
-        }
+        await printFiles(detail.files);
       },
       onDragUpdated: (details) {
         setState(() {

--- a/packages/desktop_drop/example/web/index.html
+++ b/packages/desktop_drop/example/web/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-<!--  <base href="$FLUTTER_BASE_HREF">-->
+  <base href="$FLUTTER_BASE_HREF">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
@@ -31,74 +31,29 @@
 
   <title>desktop_drop_example</title>
   <link rel="manifest" href="manifest.json">
+
+  <script>
+    // The value below is injected by flutter build, do not touch.
+    const serviceWorkerVersion = null;
+  </script>
+  <!-- This script adds the flutter initialization JS code -->
+  <script src="flutter.js" defer></script>
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
-    var scriptLoaded = false;
-    function loadMainDartJs() {
-      if (scriptLoaded) {
-        return;
-      }
-      scriptLoaded = true;
-      var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
-      scriptTag.type = 'application/javascript';
-      document.body.append(scriptTag);
-    }
-
-    if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
-                  console.log('Installed new service worker.');
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing || reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log('New service worker available.');
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
-              console.log('Loading app from service worker.');
-              loadMainDartJs();
-            }
+    window.addEventListener('load', function(ev) {
+      // Download main.dart.js
+      _flutter.loader.loadEntrypoint({
+        serviceWorker: {
+          serviceWorkerVersion: serviceWorkerVersion,
+        },
+        onEntrypointLoaded: function(engineInitializer) {
+          engineInitializer.initializeEngine().then(function(appRunner) {
+            appRunner.runApp();
           });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plaint <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
+        }
       });
-    } else {
-      // Service workers not supported. Just drop the <script> tag.
-      loadMainDartJs();
-    }
+    });
   </script>
 </body>
 </html>

--- a/packages/desktop_drop/lib/desktop_drop.dart
+++ b/packages/desktop_drop/lib/desktop_drop.dart
@@ -1,1 +1,2 @@
 export 'src/drop_target.dart';
+export 'src/drop_item.dart';

--- a/packages/desktop_drop/lib/desktop_drop_web.dart
+++ b/packages/desktop_drop/lib/desktop_drop_web.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
-import 'dart:html' as html show window, Url;
+import 'dart:html' as html;
+import 'dart:js_util' as js_util;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-import 'src/drop_item.dart';
+import 'src/web_drop_item.dart';
 
 /// A web implementation of the DesktopDrop plugin.
 class DesktopDropWeb {
@@ -25,29 +26,72 @@ class DesktopDropWeb {
     pluginInstance._registerEvents();
   }
 
+  Future<WebDropItem> _entryToWebDropItem(dynamic entry) async {
+    if (entry.isDirectory == true) {
+      final reader = js_util.callMethod(entry, 'createReader', []);
+      final entriesCompleter = Completer<List>();
+      final metadataCompleter = Completer();
+      entry.getMetadata((value) {
+        metadataCompleter.complete(value);
+      }, (error) {
+        metadataCompleter.completeError(error);
+      });
+      final metaData = await metadataCompleter.future;
+      reader.readEntries((values) {
+        entriesCompleter.complete(List.from(values));
+      }, (error) {
+        entriesCompleter.completeError(error);
+      });
+      final entries = await entriesCompleter.future;
+      final modificationTime = js_util.dartify(metaData.modificationTime);
+      final children = await Future.wait(
+        entries.map((e) => _entryToWebDropItem(e)),
+      )
+        ..removeWhere((element) => element.name == '.DS_Store' && element.type == '');
+      return WebDropItem(
+        uri: html.Url.createObjectUrlFromBlob(html.Blob([], 'directory')),
+        name: entry.name ?? '',
+        size: metaData.size ?? 0,
+        lastModified: modificationTime != null && modificationTime is DateTime
+            ? modificationTime
+            : DateTime.now(),
+        relativePath: entry.fullPath,
+        type: 'directory',
+        children: children,
+      );
+    }
+    final fileCompleter = Completer<html.File>();
+    entry.file((file) {
+      fileCompleter.complete(file);
+    }, (error) {
+      fileCompleter.completeError(error);
+    });
+    final file = await fileCompleter.future;
+    return WebDropItem(
+      uri: html.Url.createObjectUrl(file),
+      children: [],
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      relativePath: file.relativePath,
+      lastModified: file.lastModified != null
+          ? DateTime.fromMillisecondsSinceEpoch(file.lastModified!)
+          : file.lastModifiedDate,
+    );
+  }
+
   void _registerEvents() {
-    html.window.onDrop.listen((event) {
+    html.window.onDrop.listen((event) async {
       event.preventDefault();
 
       final results = <WebDropItem>[];
 
       try {
-        final items = event.dataTransfer.files;
-        if (items != null) {
-          for (final item in items) {
-            results.add(
-              WebDropItem(
-                uri: html.Url.createObjectUrl(item),
-                name: item.name,
-                size: item.size,
-                type: item.type,
-                relativePath: item.relativePath,
-                lastModified: item.lastModified != null
-                    ? DateTime.fromMillisecondsSinceEpoch(item.lastModified!)
-                    : item.lastModifiedDate,
-              ),
-            );
-          }
+        final items = event.dataTransfer.items;
+        for (var i = 0; i < (items?.length ?? 0); i++) {
+          final item = items![i];
+          final entry = item.getAsEntry();
+          results.add(await _entryToWebDropItem(entry));
         }
       } catch (e, s) {
         debugPrint('desktop_drop_web: $e $s');

--- a/packages/desktop_drop/lib/src/channel.dart
+++ b/packages/desktop_drop/lib/src/channel.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 
-import 'package:cross_file/cross_file.dart';
+import 'package:desktop_drop/src/drop_item.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-import 'drop_item.dart';
 import 'events.dart';
 import 'utils/platform.dart' if (dart.library.html) 'utils/platform_web.dart';
+import 'web_drop_item.dart';
 
 typedef RawDropListener = void Function(DropEvent);
 
@@ -64,7 +64,7 @@ class DesktopDrop {
         _notifyEvent(
           DropDoneEvent(
             location: _offset ?? Offset.zero,
-            files: paths.map((e) => XFile(e)).toList(),
+            files: paths.map((e) => DropItemFile(e)).toList(),
           ),
         );
         _offset = null;
@@ -83,20 +83,14 @@ class DesktopDrop {
         }).where((e) => e.isNotEmpty);
         _notifyEvent(DropDoneEvent(
           location: Offset(offset[0], offset[1]),
-          files: paths.map((e) => XFile(e)).toList(),
+          files: paths.map((e) => DropItemFile(e)).toList(),
         ));
         break;
       case "performOperation_web":
         final results = (call.arguments as List)
             .cast<Map>()
             .map((e) => WebDropItem.fromJson(e.cast<String, dynamic>()))
-            .map((e) => XFile(
-                  e.uri,
-                  name: e.name,
-                  length: e.size,
-                  lastModified: e.lastModified,
-                  mimeType: e.type,
-                ))
+            .map((e) => e.toDropItem())
             .toList();
         _notifyEvent(
           DropDoneEvent(location: _offset ?? Offset.zero, files: results),

--- a/packages/desktop_drop/lib/src/drop_item.dart
+++ b/packages/desktop_drop/lib/src/drop_item.dart
@@ -1,35 +1,107 @@
-class WebDropItem {
-  WebDropItem({
-    required this.uri,
-    required this.name,
-    required this.type,
-    required this.size,
-    required this.relativePath,
-    required this.lastModified,
-  });
+import 'dart:typed_data';
 
-  final String uri;
-  final String name;
-  final String type;
-  final int size;
-  final String? relativePath;
-  final DateTime lastModified;
+import 'package:cross_file/cross_file.dart';
 
-  factory WebDropItem.fromJson(Map<String, dynamic> json) => WebDropItem(
-        uri: json['uri'],
-        name: json['name'],
-        type: json['type'],
-        size: json['size'],
-        relativePath: json['relativePath'],
-        lastModified: DateTime.fromMillisecondsSinceEpoch(json['lastModified']),
-      );
+abstract class DropItem extends XFile {
+  DropItem(
+    String path, {
+    String? mimeType,
+    String? name,
+    int? length,
+    Uint8List? bytes,
+    DateTime? lastModified,
+  }) : super(path,
+            mimeType: mimeType,
+            name: name,
+            length: length,
+            bytes: bytes,
+            lastModified: lastModified);
 
-  Map<String, dynamic> toJson() => <String, dynamic>{
-        'uri': uri,
-        'name': name,
-        'type': type,
-        'size': size,
-        'relativePath': relativePath,
-        'lastModified': lastModified.millisecondsSinceEpoch,
-      };
+  DropItem.fromData(
+    Uint8List bytes, {
+    String? mimeType,
+    String? name,
+    int? length,
+    DateTime? lastModified,
+    String? path,
+  }) : super.fromData(
+          bytes,
+          mimeType: mimeType,
+          name: name,
+          length: length,
+          lastModified: lastModified,
+          path: path,
+        );
+}
+
+class DropItemFile extends DropItem {
+  DropItemFile(
+    String path, {
+    String? mimeType,
+    String? name,
+    int? length,
+    Uint8List? bytes,
+    DateTime? lastModified,
+  }) : super(
+          path,
+          mimeType: mimeType,
+          name: name,
+          length: length,
+          bytes: bytes,
+          lastModified: lastModified,
+        );
+
+  DropItemFile.fromData(
+    Uint8List bytes, {
+    String? mimeType,
+    String? name,
+    int? length,
+    DateTime? lastModified,
+    String? path,
+  }) : super.fromData(
+          bytes,
+          mimeType: mimeType,
+          name: name,
+          length: length,
+          lastModified: lastModified,
+          path: path,
+        );
+}
+
+class DropItemDirectory extends DropItem {
+  final List<DropItem> children;
+
+  DropItemDirectory(
+    String path,
+    this.children, {
+    String? mimeType,
+    String? name,
+    int? length,
+    Uint8List? bytes,
+    DateTime? lastModified,
+  }) : super(
+          path,
+          mimeType: mimeType,
+          name: name,
+          length: length,
+          bytes: bytes,
+          lastModified: lastModified,
+        );
+
+  DropItemDirectory.fromData(
+    Uint8List bytes,
+    this.children, {
+    String? mimeType,
+    String? name,
+    int? length,
+    DateTime? lastModified,
+    String? path,
+  }) : super.fromData(
+          bytes,
+          mimeType: mimeType,
+          name: name,
+          length: length,
+          lastModified: lastModified,
+          path: path,
+        );
 }

--- a/packages/desktop_drop/lib/src/drop_target.dart
+++ b/packages/desktop_drop/lib/src/drop_target.dart
@@ -1,7 +1,7 @@
-import 'package:cross_file/cross_file.dart';
 import 'package:flutter/widgets.dart';
 
 import 'channel.dart';
+import 'drop_item.dart';
 import 'events.dart';
 import 'utils/platform.dart' if (dart.library.html) 'utils/platform_web.dart';
 
@@ -13,7 +13,7 @@ class DropDoneDetails {
     required this.globalPosition,
   });
 
-  final List<XFile> files;
+  final List<DropItem> files;
   final Offset localPosition;
   final Offset globalPosition;
 }

--- a/packages/desktop_drop/lib/src/events.dart
+++ b/packages/desktop_drop/lib/src/events.dart
@@ -1,4 +1,4 @@
-import 'package:cross_file/cross_file.dart';
+import 'package:desktop_drop/src/drop_item.dart';
 import 'package:flutter/painting.dart';
 
 abstract class DropEvent {
@@ -25,7 +25,7 @@ class DropUpdateEvent extends DropEvent {
 }
 
 class DropDoneEvent extends DropEvent {
-  final List<XFile> files;
+  final List<DropItem> files;
 
   DropDoneEvent({
     required Offset location,

--- a/packages/desktop_drop/lib/src/web_drop_item.dart
+++ b/packages/desktop_drop/lib/src/web_drop_item.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+
+import 'package:desktop_drop/src/drop_item.dart';
+
+class WebDropItem {
+  WebDropItem({
+    required this.uri,
+    required this.children,
+    this.data,
+    required this.name,
+    required this.type,
+    required this.size,
+    required this.relativePath,
+    required this.lastModified,
+  });
+
+  final String uri;
+  final List<WebDropItem> children;
+  final Uint8List? data;
+  final String name;
+  final String type;
+  final int size;
+  final String? relativePath;
+  final DateTime lastModified;
+
+  factory WebDropItem.fromJson(Map<String, dynamic> json) => WebDropItem(
+        uri: json['uri'],
+        children: json['children'] == null
+            ? []
+            : (json['children'] as List)
+                .cast<Map>()
+                .map((e) => WebDropItem.fromJson(e.cast<String, dynamic>()))
+                .toList(),
+        data: json['data'] != null ? Uint8List.fromList(json['data']) : null,
+        name: json['name'],
+        type: json['type'],
+        size: json['size'],
+        relativePath: json['relativePath'],
+        lastModified: DateTime.fromMillisecondsSinceEpoch(json['lastModified']),
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'uri': uri,
+        'children': children.map((e) => e.toJson()).toList(),
+        'data': data?.toList(),
+        'name': name,
+        'type': type,
+        'size': size,
+        'relativePath': relativePath,
+        'lastModified': lastModified.millisecondsSinceEpoch,
+      };
+
+  DropItem toDropItem() {
+    if (type == 'directory') {
+      return DropItemDirectory(
+        uri,
+        children.map((e) => e.toDropItem()).toList(),
+        name: name,
+        mimeType: type,
+        length: size,
+        lastModified: lastModified,
+        bytes: data,
+      );
+    } else {
+      if (data != null) {
+        return DropItemFile.fromData(
+          data!,
+          name: name,
+          mimeType: type,
+          length: size,
+          lastModified: lastModified,
+          path: uri,
+        );
+      }
+      return DropItemFile(
+        uri,
+        name: name,
+        mimeType: type,
+        length: size,
+        lastModified: lastModified,
+        bytes: data,
+      );
+    }
+  }
+}


### PR DESCRIPTION
**My issue:**
I'm developing an application that uses the drag and drop on the desktop and web. On desktop it works perfectly well, when I drop a folder, for example, I can use the `Directory` object from the `dart:io` and iterates from all the folder's content.
But on the web we don't have the `dart:io` library, so how could I do this folder content getting?
I searched for many ways to do that, using the blob URL that is generated, using the FileReader and some other ways, nothing worked. The only way possible to do that was getting the folder content when I drop the folder, using the `DataTransferItem` from the [`DataTransferItemList`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList).

**The solution**
Using the `DataTransferItem` I can determine if the item is a File or a Directory, so I added a check if it is a Directory and iterated from the folder's content using the [`FileSystemDirectoryEntry`](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryEntry) with the `.createReader()` function that returns a [`FileSystemDirectoryReader`](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryReader) with a [`.readEntries()`](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryReader/readEntries) that returns the content listing.

With each content, I run the function recursively until I find all the files from the dragged folder (I tested with the biggest nested folder that I have, and it lagged nothing, so I don't think we need to limit that, but we could add a parameter to make this recursively optional), mapping all into `WebDropItem`, as it was.

For that change, I was needed to change the `List<XFile> files` from the `DropDoneEvent` to `List<DropItem> files`, that will not be a breaking change, since the `DropItemFile` is a class that extends `XFile`, so it will keep working as it was in all other projects that were using the `XFile`.
I created three new classes, `DropItem` that extends from `XFile`, `DropItemFile` that extends from `DropItem` and finally the `DropItemDirectory` that extends from `DropItem` and adds a new property called `children`, that is a List of `DropItem`.
So with that, we can return all the folders and contents that we want, without breaking changes and any issues 🌟

**Challenges**
I got some troubles until I got the solution working, so it could be evident on the `_entryToWebDropItem` method of the `desktop_drop_web` file.
For some reason, if I try to use the objects that dart provides me from the HTML package, it simply fails when I try to cast from the `Entry` object to the `DirectoryEntry`. So what I made was use the JS directly, using dynamic types and making my own implementation. It could look a little messy for maintenance, but it works really well and didn't fail, so if someone has other better solution for that, I'd appreciate it!

**Changes**
- Improved the print files from the example
- Updated index.html of the example
- Created `DropItem`, `DropItemFile` and `DropItemDirectory` to be used instead of `XFile` (no breaking change)
- `DropDoneDetails` now uses `DropItem` instead of `XFile`