### PR TITLE
macOS: Obtain NSWindow from FlutterPluginRegistrar

### DIFF
--- a/packages/desktop_drop/macos/Classes/DesktopDropPlugin.swift
+++ b/packages/desktop_drop/macos/Classes/DesktopDropPlugin.swift
@@ -19,8 +19,8 @@ private func findFlutterViewController(_ viewController: NSViewController?) -> F
 
 public class DesktopDropPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
-    guard let app = NSApplication.shared.delegate as? FlutterAppDelegate else { return }
-    guard let flutterWindow = app.mainFlutterWindow else { return }
+    guard let flutterView = registrar.view else { return }
+    guard let flutterWindow = flutterView.window else { return }
     guard let vc = findFlutterViewController(flutterWindow.contentViewController) else { return }
 
     let channel = FlutterMethodChannel(name: "desktop_drop", binaryMessenger: registrar.messenger)


### PR DESCRIPTION
This makes desktop_drop work even if Flutter is embedded into another application. In that case, the Flutter NSWindow is not the application main window.