### PR TITLE
[FIX] Use deprecated functions on versions older than 2.40

### DIFF
--- a/packages/desktop_webview_window/linux/CMakeLists.txt
+++ b/packages/desktop_webview_window/linux/CMakeLists.txt
@@ -9,7 +9,6 @@ set(PLUGIN_NAME "desktop_webview_window_plugin")
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WebKit IMPORTED_TARGET webkit2gtk-4.1) 
 if (NOT WebKit_FOUND)
-  add_compile_definitions(WEBKIT_OLD_USED=1)
   pkg_check_modules(WebKit REQUIRED IMPORTED_TARGET webkit2gtk-4.0)  # for backward compatibility
 endif ()
 

--- a/packages/desktop_webview_window/linux/webview_window.cc
+++ b/packages/desktop_webview_window/linux/webview_window.cc
@@ -8,6 +8,10 @@
 
 #include "message_channel_plugin.h"
 
+#if WEBKIT_MAJOR_VERSION < 2 || (WEBKIT_MAJOR_VERSION == 2 && WEBKIT_MINOR_VERSION < 40)
+#define WEBKIT_OLD_USED
+#endif
+
 namespace
 {
 


### PR DESCRIPTION
In my last PR #311, I made sure that it runs correct functions for backward compatibility.

But I came to know that for both webkit 4.0 and 4.1 after version 2.40.0 these functions are deprecated. Hence added the code to correctly run right snippet.