### PR TITLE
[desktop_webview_window] add support for getting cookies

### DIFF
--- a/packages/desktop_webview_window/.gitignore
+++ b/packages/desktop_webview_window/.gitignore
@@ -29,3 +29,5 @@
 build/
 
 .fvm
+
+.vscode

--- a/packages/desktop_webview_window/README.md
+++ b/packages/desktop_webview_window/README.md
@@ -39,8 +39,14 @@ Show a webview window on your flutter desktop application.
 
 ## linux requirement
 
+In Ubuntu/Debian:
 ```shell
-sudo apt-get install webkit2gtk4.1
+sudo apt-get install libwebkit2gtk-4.1-0 libwebkit2gtk-4.1-dev libsoup-3.0-0 libsoup-3.0-dev
+```
+
+In Fedora/RPM:
+```shell
+sudo dnf install webkit2gtk4.1 webkit2gtk4.1-devel libsoup3 libsoup3-devel
 ```
 
 ## Windows

--- a/packages/desktop_webview_window/example/lib/main.dart
+++ b/packages/desktop_webview_window/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:desktop_webview_window/desktop_webview_window.dart';
@@ -63,6 +64,7 @@ class _MyAppState extends State<MyApp> {
                     userDataFolderWindows: await _getWebViewPath(),
                   ),
                 );
+
                 webview
                   ..registerJavaScriptMessageHandler("test", (name, body) {
                     debugPrint('on javaScipt message: $name $body');
@@ -134,6 +136,20 @@ class _MyAppState extends State<MyApp> {
         titleBarTopPadding: Platform.isMacOS ? 20 : 0,
       ),
     );
+
+    Timer.periodic(const Duration(seconds: 1), (timer) async {
+      try {
+        final cookies = await webview.getAllCookies();
+
+        for (final cookie in cookies) {
+          debugPrint('cookie: $cookie');
+        }
+      } catch (e, stack) {
+        debugPrint('getAllCookies error: $e');
+        debugPrintStack(stackTrace: stack);
+      }
+    });
+
     webview
       ..setBrightness(Brightness.dark)
       ..setApplicationNameForUserAgent(" WebviewExample/1.0.0")

--- a/packages/desktop_webview_window/example/lib/main.dart
+++ b/packages/desktop_webview_window/example/lib/main.dart
@@ -141,6 +141,10 @@ class _MyAppState extends State<MyApp> {
       try {
         final cookies = await webview.getAllCookies();
 
+        if (cookies.isEmpty) {
+          debugPrint('no cookies');
+        }
+
         for (final cookie in cookies) {
           debugPrint('cookie: $cookie');
         }

--- a/packages/desktop_webview_window/example/lib/main.dart
+++ b/packages/desktop_webview_window/example/lib/main.dart
@@ -137,16 +137,16 @@ class _MyAppState extends State<MyApp> {
       ),
     );
 
-    Timer.periodic(const Duration(seconds: 1), (timer) async {
+    final timer = Timer.periodic(const Duration(seconds: 1), (timer) async {
       try {
         final cookies = await webview.getAllCookies();
 
         if (cookies.isEmpty) {
-          debugPrint('no cookies');
+          debugPrint('⚠️ no cookies found');
         }
 
         for (final cookie in cookies) {
-          debugPrint('cookie: $cookie');
+          debugPrint('cookie: ${cookie.toJson()}');
         }
       } catch (e, stack) {
         debugPrint('getAllCookies error: $e');
@@ -168,8 +168,10 @@ class _MyAppState extends State<MyApp> {
         // grant navigation request
         return true;
       })
+      ..openDevToolsWindow()
       ..onClose.whenComplete(() {
         debugPrint("on close");
+        timer.cancel();
       });
     await Future.delayed(const Duration(seconds: 2));
     for (final javaScript in _javaScriptToEval) {

--- a/packages/desktop_webview_window/example/macos/Podfile
+++ b/packages/desktop_webview_window/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.12'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/desktop_webview_window/example/macos/Podfile.lock
+++ b/packages/desktop_webview_window/example/macos/Podfile.lock
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
 
 SPEC CHECKSUMS:
-  desktop_webview_window: d4365e71bcd4e1aa0c14cf0377aa24db0c16a7e2
+  desktop_webview_window: 89bb3d691f4c80314a10be312f4cd35db93a9d5a
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
 
-PODFILE CHECKSUM: c7161fcf45d4fd9025dc0f48a76d6e64e52f8176
+PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/packages/desktop_webview_window/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/desktop_webview_window/example/macos/Runner.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -426,7 +426,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -553,7 +553,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -574,7 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/packages/desktop_webview_window/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/desktop_webview_window/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/desktop_webview_window/example/pubspec.lock
+++ b/packages/desktop_webview_window/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.3"
+    version: "0.2.4"
   fake_async:
     dependency: transitive
     description:
@@ -98,6 +98,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -110,34 +134,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -267,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -279,14 +303,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "14.2.1"
   win32:
     dependency: transitive
     description:
@@ -304,5 +328,5 @@ packages:
     source: hosted
     version: "0.2.0+2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/desktop_webview_window/example/pubspec.lock
+++ b/packages/desktop_webview_window/example/pubspec.lock
@@ -102,26 +102,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "13.0.0"
   win32:
     dependency: transitive
     description:
@@ -328,5 +328,5 @@ packages:
     source: hosted
     version: "0.2.0+2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.2.0-0 <4.0.0"
+  flutter: ">=3.0.0"

--- a/packages/desktop_webview_window/example/windows/flutter/CMakeLists.txt
+++ b/packages/desktop_webview_window/example/windows/flutter/CMakeLists.txt
@@ -9,6 +9,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -91,7 +96,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/packages/desktop_webview_window/lib/src/cookie.dart
+++ b/packages/desktop_webview_window/lib/src/cookie.dart
@@ -1,0 +1,34 @@
+class WebviewCookie {
+  final String name;
+  final String value;
+  final String domain;
+  final String path;
+  final DateTime expires;
+  final bool secure;
+  final bool httpOnly;
+  final bool sessionOnly;
+
+  WebviewCookie({
+    required this.name,
+    required this.value,
+    required this.domain,
+    required this.path,
+    required this.expires,
+    required this.secure,
+    required this.httpOnly,
+    required this.sessionOnly,
+  });
+
+  factory WebviewCookie.fromJson(Map<String, dynamic> json) {
+    return WebviewCookie(
+      name: json['name'],
+      value: json['value'],
+      domain: json['domain'],
+      expires: DateTime.parse(json['expires']),
+      httpOnly: json['httpOnly'],
+      path: json['path'],
+      secure: json['secure'],
+      sessionOnly: json['sessionOnly'],
+    );
+  }
+}

--- a/packages/desktop_webview_window/lib/src/cookie.dart
+++ b/packages/desktop_webview_window/lib/src/cookie.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/widgets.dart';
-
 class WebviewCookie {
   final String name;
   final String value;
@@ -22,7 +20,6 @@ class WebviewCookie {
   });
 
   factory WebviewCookie.fromJson(Map<String, dynamic> json) {
-    debugPrint('WebviewCookie.fromJson: $json');
     return WebviewCookie(
       name: json['name'],
       value: json['value'],
@@ -37,5 +34,19 @@ class WebviewCookie {
       secure: json['secure'],
       sessionOnly: json['sessionOnly'],
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'value': value,
+      'domain': domain,
+      'path': path,
+      'expires':
+          expires == null ? null : expires!.millisecondsSinceEpoch ~/ 1000,
+      'secure': secure,
+      'httpOnly': httpOnly,
+      'sessionOnly': sessionOnly,
+    };
   }
 }

--- a/packages/desktop_webview_window/lib/src/cookie.dart
+++ b/packages/desktop_webview_window/lib/src/cookie.dart
@@ -29,10 +29,10 @@ class WebviewCookie {
           : DateTime.fromMillisecondsSinceEpoch(
               ((json['expires'] as num) * 1000).toInt(),
             ),
-      httpOnly: json['httpOnly'],
+      httpOnly: json['httpOnly'] ?? false,
       path: json['path'],
-      secure: json['secure'],
-      sessionOnly: json['sessionOnly'],
+      secure: json['secure'] ?? false,
+      sessionOnly: json['sessionOnly'] ?? false,
     );
   }
 

--- a/packages/desktop_webview_window/lib/src/cookie.dart
+++ b/packages/desktop_webview_window/lib/src/cookie.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/widgets.dart';
+
 class WebviewCookie {
   final String name;
   final String value;
   final String domain;
   final String path;
-  final DateTime expires;
+  final DateTime? expires;
   final bool secure;
   final bool httpOnly;
   final bool sessionOnly;
@@ -20,11 +22,16 @@ class WebviewCookie {
   });
 
   factory WebviewCookie.fromJson(Map<String, dynamic> json) {
+    debugPrint('WebviewCookie.fromJson: $json');
     return WebviewCookie(
       name: json['name'],
       value: json['value'],
       domain: json['domain'],
-      expires: DateTime.parse(json['expires']),
+      expires: json['expires'] == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(
+              ((json['expires'] as num) * 1000).toInt(),
+            ),
       httpOnly: json['httpOnly'],
       path: json['path'],
       secure: json['secure'],

--- a/packages/desktop_webview_window/lib/src/webview.dart
+++ b/packages/desktop_webview_window/lib/src/webview.dart
@@ -1,3 +1,4 @@
+import 'package:desktop_webview_window/src/cookie.dart';
 import 'package:flutter/foundation.dart';
 
 /// Handle custom message from JavaScript in your app.
@@ -35,7 +36,7 @@ abstract class Webview {
   void setPromptHandler(PromptHandler? handler);
 
   /// Navigates to the given URL.
-  void launch(String url, {bool triggerOnUrlRequestEvent=true});
+  void launch(String url, {bool triggerOnUrlRequestEvent = true});
 
   /// change webview theme.
   ///
@@ -63,7 +64,7 @@ abstract class Webview {
   Future<void> bringToForeground({bool maximized = false});
 
   /// get position, extents and maximization info of the webview window
-  Future<Map<dynamic,dynamic>?> getPositionalParameters();
+  Future<Map<dynamic, dynamic>?> getPositionalParameters();
 
   /// Reload the current page.
   Future<void> reload();
@@ -95,4 +96,6 @@ abstract class Webview {
 
   /// post a web message as JSON to the top level document in this WebView
   Future<void> postWebMessageAsJson(String webMessage);
+
+  Future<List<WebviewCookie>> getAllCookies();
 }

--- a/packages/desktop_webview_window/lib/src/webview_impl.dart
+++ b/packages/desktop_webview_window/lib/src/webview_impl.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:desktop_webview_window/src/cookie.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
@@ -61,7 +62,7 @@ class WebviewImpl extends Webview {
   }
 
   bool notifyUrlChanged(String url) {
-    if(_onUrlRequestCallback != null) {
+    if (_onUrlRequestCallback != null) {
       return _onUrlRequestCallback!(url);
     } else {
       return true;
@@ -123,7 +124,7 @@ class WebviewImpl extends Webview {
   }
 
   @override
-  void launch(String url, {bool triggerOnUrlRequestEvent=true}) async {
+  void launch(String url, {bool triggerOnUrlRequestEvent = true}) async {
     await channel.invokeMethod("launch", {
       "url": url,
       "viewId": viewId,
@@ -201,7 +202,7 @@ class WebviewImpl extends Webview {
   }
 
   @override
-  Future<Map<dynamic,dynamic>?> getPositionalParameters() async {
+  Future<Map<dynamic, dynamic>?> getPositionalParameters() async {
     return await channel.invokeMethod("getPositionalParameters", {
       "viewId": viewId,
     });
@@ -243,7 +244,8 @@ class WebviewImpl extends Webview {
   }
 
   @override
-  void removeOnWebMessageReceivedCallback(OnWebMessageReceivedCallback callback) {
+  void removeOnWebMessageReceivedCallback(
+      OnWebMessageReceivedCallback callback) {
     _onWebMessageReceivedCallbacks.remove(callback);
   }
 
@@ -281,5 +283,17 @@ class WebviewImpl extends Webview {
       "viewId": viewId,
       "webMessage": webMessage,
     });
+  }
+
+  @override
+  Future<List<WebviewCookie>> getAllCookies() async {
+    final result = await channel.invokeListMethod<Map>("getAllCookies", {
+      "viewId": viewId,
+    });
+
+    return result
+            ?.map((e) => WebviewCookie.fromJson(e.cast<String, dynamic>()))
+            .toList() ??
+        [];
   }
 }

--- a/packages/desktop_webview_window/linux/CMakeLists.txt
+++ b/packages/desktop_webview_window/linux/CMakeLists.txt
@@ -12,6 +12,12 @@ if (NOT WebKit_FOUND)
   pkg_check_modules(WebKit REQUIRED IMPORTED_TARGET webkit2gtk-4.0)  # for backward compatibility
 endif ()
 
+pkg_check_modules(LibSoup REQUIRED IMPORTED_TARGET libsoup-3.0)
+if (NOT LibSoup_FOUND)
+  pkg_check_modules(LibSoup REQUIRED IMPORTED_TARGET libsoup-2.4)
+endif()
+
+
 add_library(${PLUGIN_NAME} SHARED
         "desktop_webview_window_plugin.cc"
         webview_window.cc

--- a/packages/desktop_webview_window/linux/desktop_webview_window_plugin.cc
+++ b/packages/desktop_webview_window/linux/desktop_webview_window_plugin.cc
@@ -214,18 +214,19 @@ static void webview_window_plugin_handle_method_call(
       return;
     }
 
-    auto *data = static_cast<FlValue **>(g_new(FlValue *, 1));
-    self->windows->at(window_id)->GetAllCookies(data);
+    FlValue *data = nullptr;
 
-    if (*data == nullptr) {
+    data = self->windows->at(window_id)->GetAllCookies();
+
+    if (data == nullptr) {
       fl_method_call_respond_error(method_call, "0", "get all cookies failed",
                                    nullptr, nullptr);
       return;
     }
 
-    fl_value_unref(*data);
 
-    fl_method_call_respond_success(method_call, *data, nullptr);
+    fl_method_call_respond_success(method_call, data, nullptr);
+    fl_value_unref(data);
   } else if (strcmp(method, "close") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {

--- a/packages/desktop_webview_window/linux/desktop_webview_window_plugin.cc
+++ b/packages/desktop_webview_window/linux/desktop_webview_window_plugin.cc
@@ -2,15 +2,14 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
-
-#include <memory>
-#include <cstring>
-#include <map>
-
 #include <webkit2/webkit2.h>
 
-#include "webview_window.h"
+#include <cstring>
+#include <map>
+#include <memory>
+
 #include "message_channel_plugin.h"
+#include "webview_window.h"
 
 namespace {
 
@@ -18,7 +17,7 @@ int64_t next_window_id_ = 0;
 
 }
 
-#define WEBVIEW_WINDOW_PLUGIN(obj) \
+#define WEBVIEW_WINDOW_PLUGIN(obj)                                     \
   (G_TYPE_CHECK_INSTANCE_CAST((obj), webview_window_plugin_get_type(), \
                               WebviewWindowPlugin))
 
@@ -32,21 +31,22 @@ G_DEFINE_TYPE(WebviewWindowPlugin, webview_window_plugin, g_object_get_type())
 
 // Called when a method call is received from Flutter.
 static void webview_window_plugin_handle_method_call(
-    WebviewWindowPlugin *self,
-    FlMethodCall *method_call) {
-
+    WebviewWindowPlugin *self, FlMethodCall *method_call) {
   const gchar *method = fl_method_call_get_name(method_call);
 
   if (strcmp(method, "create") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "create args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0", "create args is not map",
+                                   nullptr, nullptr);
       return;
     }
     auto width = fl_value_get_int(fl_value_lookup_string(args, "windowWidth"));
-    auto height = fl_value_get_int(fl_value_lookup_string(args, "windowHeight"));
+    auto height =
+        fl_value_get_int(fl_value_lookup_string(args, "windowHeight"));
     auto title = fl_value_get_string(fl_value_lookup_string(args, "title"));
-    auto title_bar_height = fl_value_get_int(fl_value_lookup_string(args, "titleBarHeight"));
+    auto title_bar_height =
+        fl_value_get_int(fl_value_lookup_string(args, "titleBarHeight"));
 
     auto window_id = next_window_id_;
     g_object_ref(self);
@@ -55,21 +55,26 @@ static void webview_window_plugin_handle_method_call(
         [self, window_id]() {
           self->windows->erase(window_id);
           g_object_unref(self);
-        }, title, width, height, title_bar_height);
+        },
+        title, width, height, title_bar_height);
     self->windows->insert({window_id, std::move(webview)});
     next_window_id_++;
-    fl_method_call_respond_success(method_call, fl_value_new_int(window_id), nullptr);
+    fl_method_call_respond_success(method_call, fl_value_new_int(window_id),
+                                   nullptr);
   } else if (strcmp(method, "launch") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "create args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0", "create args is not map",
+                                   nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
     auto url = fl_value_get_string(fl_value_lookup_string(args, "url"));
 
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
 
@@ -78,58 +83,70 @@ static void webview_window_plugin_handle_method_call(
   } else if (strcmp(method, "addScriptToExecuteOnDocumentCreated") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0", "args is not map", nullptr,
+                                   nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
-    auto java_script = fl_value_get_string(fl_value_lookup_string(args, "javaScript"));
+    auto java_script =
+        fl_value_get_string(fl_value_lookup_string(args, "javaScript"));
 
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
     self->windows->at(window_id)->RunJavaScriptWhenContentReady(java_script);
     fl_method_call_respond_success(method_call, nullptr, nullptr);
   } else if (strcmp(method, "clearAll") == 0) {
-    for (const auto &item: *self->windows) {
+    for (const auto &item : *self->windows) {
       item.second->Close();
     }
-    // If application didn't create a webview, but we called webkit_website_data_manager_clear, there will be a segment fault.
-    // To avoid crash, we create a fake webview first and then clear all data.
+    // If application didn't create a webview, but we called
+    // webkit_website_data_manager_clear, there will be a segment fault. To
+    // avoid crash, we create a fake webview first and then clear all data.
     auto *web_view = webkit_web_view_new();
     auto *context = webkit_web_view_get_context(WEBKIT_WEB_VIEW(web_view));
-    auto *website_data_manager = webkit_web_context_get_website_data_manager(context);
-    webkit_website_data_manager_clear(website_data_manager, WEBKIT_WEBSITE_DATA_ALL, 0,
-                                      nullptr, nullptr, nullptr);
+    auto *website_data_manager =
+        webkit_web_context_get_website_data_manager(context);
+    webkit_website_data_manager_clear(website_data_manager,
+                                      WEBKIT_WEBSITE_DATA_ALL, 0, nullptr,
+                                      nullptr, nullptr);
     fl_method_call_respond_success(method_call, nullptr, nullptr);
   } else if (strcmp(method, "setApplicationNameForUserAgent") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call,
-                                   "0",
-                                   "setApplicationNameForUserAgent args is not map",
-                                   nullptr,
-                                   nullptr);
+      fl_method_call_respond_error(
+          method_call, "0", "setApplicationNameForUserAgent args is not map",
+          nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
-    auto application_name = fl_value_get_string(fl_value_lookup_string(args, "applicationName"));
+    auto application_name =
+        fl_value_get_string(fl_value_lookup_string(args, "applicationName"));
 
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
-    self->windows->at(window_id)->SetApplicationNameForUserAgent(application_name);
+    self->windows->at(window_id)->SetApplicationNameForUserAgent(
+        application_name);
     fl_method_call_respond_success(method_call, nullptr, nullptr);
   } else if (strcmp(method, "back") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "back args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0", "back args is not map",
+                                   nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
     self->windows->at(window_id)->GoBack();
@@ -137,12 +154,15 @@ static void webview_window_plugin_handle_method_call(
   } else if (strcmp(method, "forward") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "forward args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0", "forward args is not map",
+                                   nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
     self->windows->at(window_id)->GoForward();
@@ -150,12 +170,15 @@ static void webview_window_plugin_handle_method_call(
   } else if (strcmp(method, "reload") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "reload args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0", "reload args is not map",
+                                   nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
     self->windows->at(window_id)->Reload();
@@ -163,25 +186,58 @@ static void webview_window_plugin_handle_method_call(
   } else if (strcmp(method, "stop") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "stop args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0", "stop args is not map",
+                                   nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
     self->windows->at(window_id)->StopLoading();
     fl_method_call_respond_success(method_call, nullptr, nullptr);
-  } else if (strcmp(method, "close") == 0) {
+  } else if (strcmp(method, "getAllCookies") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "close args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(
+          method_call, "0", "getAllCookies args is not map", nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
+      return;
+    }
+
+    auto *data = static_cast<FlValue **>(g_new(FlValue *, 1));
+    self->windows->at(window_id)->GetAllCookies(data);
+
+    if (*data == nullptr) {
+      fl_method_call_respond_error(method_call, "0", "get all cookies failed",
+                                   nullptr, nullptr);
+      return;
+    }
+
+    fl_value_unref(*data);
+
+    fl_method_call_respond_success(method_call, *data, nullptr);
+  } else if (strcmp(method, "close") == 0) {
+    auto *args = fl_method_call_get_args(method_call);
+    if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
+      fl_method_call_respond_error(method_call, "0", "close args is not map",
+                                   nullptr, nullptr);
+      return;
+    }
+    auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
+    if (!self->windows->count(window_id)) {
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
     self->windows->at(window_id)->Close();
@@ -189,20 +245,24 @@ static void webview_window_plugin_handle_method_call(
   } else if (strcmp(method, "evaluateJavaScript") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     if (fl_value_get_type(args) != FL_VALUE_TYPE_MAP) {
-      fl_method_call_respond_error(method_call, "0", "evaluateJavaScript args is not map", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "evaluateJavaScript args is not map",
+                                   nullptr, nullptr);
       return;
     }
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "viewId"));
     if (!self->windows->count(window_id)) {
-      fl_method_call_respond_error(method_call, "0", "can not found webview for viewId", nullptr, nullptr);
+      fl_method_call_respond_error(method_call, "0",
+                                   "can not found webview for viewId", nullptr,
+                                   nullptr);
       return;
     }
-    auto *js = fl_value_get_string(fl_value_lookup_string(args, "javaScriptString"));
+    auto *js =
+        fl_value_get_string(fl_value_lookup_string(args, "javaScriptString"));
     self->windows->at(window_id)->EvaluateJavaScript(js, method_call);
   } else {
     fl_method_call_respond_not_implemented(method_call, nullptr);
   }
-
 }
 
 static void webview_window_plugin_dispose(GObject *object) {
@@ -225,7 +285,8 @@ static void method_call_cb(FlMethodChannel *channel, FlMethodCall *method_call,
   webview_window_plugin_handle_method_call(plugin, method_call);
 }
 
-void desktop_webview_window_plugin_register_with_registrar(FlPluginRegistrar *registrar) {
+void desktop_webview_window_plugin_register_with_registrar(
+    FlPluginRegistrar *registrar) {
   client_message_channel_plugin_register_with_registrar(registrar);
 
   WebviewWindowPlugin *plugin = WEBVIEW_WINDOW_PLUGIN(
@@ -234,13 +295,11 @@ void desktop_webview_window_plugin_register_with_registrar(FlPluginRegistrar *re
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
   g_autoptr(FlMethodChannel) channel =
       fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
-                            "webview_window",
-                            FL_METHOD_CODEC(codec));
+                            "webview_window", FL_METHOD_CODEC(codec));
   g_object_ref(channel);
   plugin->method_channel = channel;
-  fl_method_channel_set_method_call_handler(channel, method_call_cb,
-                                            g_object_ref(plugin),
-                                            g_object_unref);
+  fl_method_channel_set_method_call_handler(
+      channel, method_call_cb, g_object_ref(plugin), g_object_unref);
 
   g_object_unref(plugin);
 }

--- a/packages/desktop_webview_window/linux/webview_window.cc
+++ b/packages/desktop_webview_window/linux/webview_window.cc
@@ -8,84 +8,74 @@
 
 #include "message_channel_plugin.h"
 
-#if WEBKIT_MAJOR_VERSION < 2 || (WEBKIT_MAJOR_VERSION == 2 && WEBKIT_MINOR_VERSION < 40)
+#if WEBKIT_MAJOR_VERSION < 2 || \
+    (WEBKIT_MAJOR_VERSION == 2 && WEBKIT_MINOR_VERSION < 40)
 #define WEBKIT_OLD_USED
 #endif
 
-namespace
-{
+namespace {
 
-  gboolean on_load_failed_with_tls_errors(
-      WebKitWebView *web_view,
-      char *failing_uri,
-      GTlsCertificate *certificate,
-      GTlsCertificateFlags errors,
-      gpointer user_data)
-  {
-    auto *webview = static_cast<WebviewWindow *>(user_data);
-    g_critical("on_load_failed_with_tls_errors: %s %p error= %d", failing_uri, webview, errors);
-    // TODO allow certificate for some certificate ?
-    // maybe we can use the pem from https://source.chromium.org/chromium/chromium/src/+/master:net/data/ssl/ev_roots/
-    //  webkit_web_context_allow_tls_certificate_for_host(webkit_web_view_get_context(web_view), certificate, uri->host);
-    //  webkit_web_view_load_uri(web_view, failing_uri);
-    return false;
-  }
-
-  GtkWidget *on_create(WebKitWebView *web_view,
-                       WebKitNavigationAction *navigation_action,
-                       gpointer user_data)
-  {
-    return GTK_WIDGET(web_view);
-  }
-
-  void on_load_changed(WebKitWebView *web_view,
-                       WebKitLoadEvent load_event,
-                       gpointer user_data)
-  {
-    auto *window = static_cast<WebviewWindow *>(user_data);
-    window->OnLoadChanged(load_event);
-  }
-
-  gboolean decide_policy_cb(WebKitWebView *web_view,
-                            WebKitPolicyDecision *decision,
-                            WebKitPolicyDecisionType type,
-                            gpointer user_data)
-  {
-    auto *window = static_cast<WebviewWindow *>(user_data);
-    return window->DecidePolicy(decision, type);
-  }
-
+gboolean on_load_failed_with_tls_errors(WebKitWebView *web_view,
+                                        char *failing_uri,
+                                        GTlsCertificate *certificate,
+                                        GTlsCertificateFlags errors,
+                                        gpointer user_data) {
+  auto *webview = static_cast<WebviewWindow *>(user_data);
+  g_critical("on_load_failed_with_tls_errors: %s %p error= %d", failing_uri,
+             webview, errors);
+  // TODO allow certificate for some certificate ?
+  // maybe we can use the pem from
+  // https://source.chromium.org/chromium/chromium/src/+/master:net/data/ssl/ev_roots/
+  //  webkit_web_context_allow_tls_certificate_for_host(webkit_web_view_get_context(web_view),
+  //  certificate, uri->host); webkit_web_view_load_uri(web_view, failing_uri);
+  return false;
 }
 
-WebviewWindow::WebviewWindow(
-    FlMethodChannel *method_channel,
-    int64_t window_id,
-    std::function<void()> on_close_callback,
-    const std::string &title,
-    int width,
-    int height,
-    int title_bar_height) : method_channel_(method_channel),
-                            window_id_(window_id),
-                            on_close_callback_(std::move(on_close_callback)),
-                            default_user_agent_()
-{
+GtkWidget *on_create(WebKitWebView *web_view,
+                     WebKitNavigationAction *navigation_action,
+                     gpointer user_data) {
+  return GTK_WIDGET(web_view);
+}
+
+void on_load_changed(WebKitWebView *web_view, WebKitLoadEvent load_event,
+                     gpointer user_data) {
+  auto *window = static_cast<WebviewWindow *>(user_data);
+  window->OnLoadChanged(load_event);
+}
+
+gboolean decide_policy_cb(WebKitWebView *web_view,
+                          WebKitPolicyDecision *decision,
+                          WebKitPolicyDecisionType type, gpointer user_data) {
+  auto *window = static_cast<WebviewWindow *>(user_data);
+  return window->DecidePolicy(decision, type);
+}
+
+}  // namespace
+
+WebviewWindow::WebviewWindow(FlMethodChannel *method_channel, int64_t window_id,
+                             std::function<void()> on_close_callback,
+                             const std::string &title, int width, int height,
+                             int title_bar_height)
+    : method_channel_(method_channel),
+      window_id_(window_id),
+      on_close_callback_(std::move(on_close_callback)),
+      default_user_agent_() {
   g_object_ref(method_channel_);
 
   window_ = gtk_window_new(GTK_WINDOW_TOPLEVEL);
   g_signal_connect(G_OBJECT(window_), "destroy",
-                   G_CALLBACK(+[](GtkWidget *, gpointer arg)
-                              {
-                                auto *window = static_cast<WebviewWindow *>(arg);
-                                if (window->on_close_callback_)
-                                {
-                                  window->on_close_callback_();
-                                }
-                                auto *args = fl_value_new_map();
-                                fl_value_set(args, fl_value_new_string("id"), fl_value_new_int(window->window_id_));
-                                fl_method_channel_invoke_method(
-                                    FL_METHOD_CHANNEL(window->method_channel_), "onWindowClose", args,
-                                    nullptr, nullptr, nullptr);
-                              }),
+                   G_CALLBACK(+[](GtkWidget *, gpointer arg) {
+                     auto *window = static_cast<WebviewWindow *>(arg);
+                     if (window->on_close_callback_) {
+                       window->on_close_callback_();
+                     }
+                     auto *args = fl_value_new_map();
+                     fl_value_set(args, fl_value_new_string("id"),
+                                  fl_value_new_int(window->window_id_));
+                     fl_method_channel_invoke_method(
+                         FL_METHOD_CHANNEL(window->method_channel_),
+                         "onWindowClose", args, nullptr, nullptr, nullptr);
+                   }),
                    this);
   gtk_window_set_title(GTK_WINDOW(window_), title.c_str());
   gtk_window_set_default_size(GTK_WINDOW(window_), width, height);
@@ -96,13 +86,17 @@ WebviewWindow::WebviewWindow(
 
   // initial flutter_view
   g_autoptr(FlDartProject) project = fl_dart_project_new();
-  const char *args[] = {"web_view_title_bar", g_strdup_printf("%ld", window_id), nullptr};
-  fl_dart_project_set_dart_entrypoint_arguments(project, const_cast<char **>(args));
+  const char *args[] = {"web_view_title_bar", g_strdup_printf("%ld", window_id),
+                        nullptr};
+  fl_dart_project_set_dart_entrypoint_arguments(project,
+                                                const_cast<char **>(args));
   auto *title_bar = fl_view_new(project);
 
   g_autoptr(FlPluginRegistrar) desktop_webview_window_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(FL_PLUGIN_REGISTRY(title_bar), "DesktopWebviewWindowPlugin");
-  client_message_channel_plugin_register_with_registrar(desktop_webview_window_registrar);
+      fl_plugin_registry_get_registrar_for_plugin(FL_PLUGIN_REGISTRY(title_bar),
+                                                  "DesktopWebviewWindowPlugin");
+  client_message_channel_plugin_register_with_registrar(
+      desktop_webview_window_registrar);
 
   gtk_widget_set_size_request(GTK_WIDGET(title_bar), -1, title_bar_height);
   gtk_widget_set_vexpand(GTK_WIDGET(title_bar), FALSE);
@@ -112,8 +106,7 @@ WebviewWindow::WebviewWindow(
   webview_ = webkit_web_view_new();
   g_signal_connect(G_OBJECT(webview_), "load-failed-with-tls-errors",
                    G_CALLBACK(on_load_failed_with_tls_errors), this);
-  g_signal_connect(G_OBJECT(webview_), "create",
-                   G_CALLBACK(on_create), this);
+  g_signal_connect(G_OBJECT(webview_), "create", G_CALLBACK(on_create), this);
   g_signal_connect(G_OBJECT(webview_), "load-changed",
                    G_CALLBACK(on_load_changed), this);
   g_signal_connect(G_OBJECT(webview_), "decide-policy",
@@ -128,130 +121,184 @@ WebviewWindow::WebviewWindow(
   gtk_widget_grab_focus(GTK_WIDGET(webview_));
 
   // FROM: https://github.com/leanflutter/window_manager/pull/343
-  // Disconnect all delete-event handlers first in flutter 3.10.1, which causes delete_event not working.
-  // Issues from flutter/engine: https://github.com/flutter/engine/pull/40033
-  guint handler_id = g_signal_handler_find(window_, G_SIGNAL_MATCH_DATA, 0, 0, NULL, NULL, title_bar);
-  if (handler_id > 0)
-  {
+  // Disconnect all delete-event handlers first in flutter 3.10.1, which causes
+  // delete_event not working. Issues from flutter/engine:
+  // https://github.com/flutter/engine/pull/40033
+  guint handler_id = g_signal_handler_find(window_, G_SIGNAL_MATCH_DATA, 0, 0,
+                                           NULL, NULL, title_bar);
+  if (handler_id > 0) {
     g_signal_handler_disconnect(window_, handler_id);
   }
 }
 
-WebviewWindow::~WebviewWindow()
-{
+WebviewWindow::~WebviewWindow() {
   g_object_unref(method_channel_);
   printf("~WebviewWindow\n");
 }
 
-void WebviewWindow::Navigate(const char *url)
-{
+void WebviewWindow::Navigate(const char *url) {
   webkit_web_view_load_uri(WEBKIT_WEB_VIEW(webview_), url);
 }
 
-void WebviewWindow::RunJavaScriptWhenContentReady(const char *java_script)
-{
-  auto *manager = webkit_web_view_get_user_content_manager(WEBKIT_WEB_VIEW(webview_));
+void WebviewWindow::RunJavaScriptWhenContentReady(const char *java_script) {
+  auto *manager =
+      webkit_web_view_get_user_content_manager(WEBKIT_WEB_VIEW(webview_));
   webkit_user_content_manager_add_script(
       manager,
-      webkit_user_script_new(java_script,
-                             WEBKIT_USER_CONTENT_INJECT_TOP_FRAME,
+      webkit_user_script_new(java_script, WEBKIT_USER_CONTENT_INJECT_TOP_FRAME,
                              WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START,
-                             nullptr,
-                             nullptr));
+                             nullptr, nullptr));
 }
 
-void WebviewWindow::SetApplicationNameForUserAgent(const std::string &app_name)
-{
+void WebviewWindow::SetApplicationNameForUserAgent(
+    const std::string &app_name) {
   auto *setting = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(webview_));
-  webkit_settings_set_user_agent(setting, (default_user_agent_ + app_name).c_str());
+  webkit_settings_set_user_agent(setting,
+                                 (default_user_agent_ + app_name).c_str());
 }
 
-void WebviewWindow::Close()
-{
-  gtk_window_close(GTK_WINDOW(window_));
-}
+void WebviewWindow::Close() { gtk_window_close(GTK_WINDOW(window_)); }
 
-void WebviewWindow::OnLoadChanged(WebKitLoadEvent load_event)
-{
+void WebviewWindow::OnLoadChanged(WebKitLoadEvent load_event) {
   // notify history changed event.
   {
     auto can_go_back = webkit_web_view_can_go_back(WEBKIT_WEB_VIEW(webview_));
-    auto can_go_forward = webkit_web_view_can_go_forward(WEBKIT_WEB_VIEW(webview_));
+    auto can_go_forward =
+        webkit_web_view_can_go_forward(WEBKIT_WEB_VIEW(webview_));
     auto *args = fl_value_new_map();
     fl_value_set(args, fl_value_new_string("id"), fl_value_new_int(window_id_));
-    fl_value_set(args, fl_value_new_string("canGoBack"), fl_value_new_bool(can_go_back));
-    fl_value_set(args, fl_value_new_string("canGoForward"), fl_value_new_bool(can_go_forward));
-    fl_method_channel_invoke_method(
-        FL_METHOD_CHANNEL(method_channel_), "onHistoryChanged", args,
-        nullptr, nullptr, nullptr);
+    fl_value_set(args, fl_value_new_string("canGoBack"),
+                 fl_value_new_bool(can_go_back));
+    fl_value_set(args, fl_value_new_string("canGoForward"),
+                 fl_value_new_bool(can_go_forward));
+    fl_method_channel_invoke_method(FL_METHOD_CHANNEL(method_channel_),
+                                    "onHistoryChanged", args, nullptr, nullptr,
+                                    nullptr);
   }
 
   // notify load start/finished event.
-  switch (load_event)
-  {
-  case WEBKIT_LOAD_STARTED:
-  {
-    auto *args = fl_value_new_map();
-    fl_value_set(args, fl_value_new_string("id"), fl_value_new_int(window_id_));
-    fl_method_channel_invoke_method(
-        FL_METHOD_CHANNEL(method_channel_), "onNavigationStarted", args,
-        nullptr, nullptr, nullptr);
-    break;
-  }
-  case WEBKIT_LOAD_FINISHED:
-  {
-    auto *args = fl_value_new_map();
-    fl_value_set(args, fl_value_new_string("id"), fl_value_new_int(window_id_));
-    fl_method_channel_invoke_method(
-        FL_METHOD_CHANNEL(method_channel_), "onNavigationCompleted", args,
-        nullptr, nullptr, nullptr);
-    break;
-  }
-  default:
-    break;
+  switch (load_event) {
+    case WEBKIT_LOAD_STARTED: {
+      auto *args = fl_value_new_map();
+      fl_value_set(args, fl_value_new_string("id"),
+                   fl_value_new_int(window_id_));
+      fl_method_channel_invoke_method(FL_METHOD_CHANNEL(method_channel_),
+                                      "onNavigationStarted", args, nullptr,
+                                      nullptr, nullptr);
+      break;
+    }
+    case WEBKIT_LOAD_FINISHED: {
+      auto *args = fl_value_new_map();
+      fl_value_set(args, fl_value_new_string("id"),
+                   fl_value_new_int(window_id_));
+      fl_method_channel_invoke_method(FL_METHOD_CHANNEL(method_channel_),
+                                      "onNavigationCompleted", args, nullptr,
+                                      nullptr, nullptr);
+      break;
+    }
+    default:
+      break;
   }
 }
 
-void WebviewWindow::GoForward()
-{
+void WebviewWindow::GoForward() {
   webkit_web_view_go_forward(WEBKIT_WEB_VIEW(webview_));
 }
 
-void WebviewWindow::GoBack()
-{
+void WebviewWindow::GoBack() {
   webkit_web_view_go_back(WEBKIT_WEB_VIEW(webview_));
 }
 
-void WebviewWindow::Reload()
-{
+void WebviewWindow::Reload() {
   webkit_web_view_reload(WEBKIT_WEB_VIEW(webview_));
 }
 
-void WebviewWindow::StopLoading()
-{
+void WebviewWindow::StopLoading() {
   webkit_web_view_stop_loading(WEBKIT_WEB_VIEW(webview_));
 }
 
-gboolean WebviewWindow::DecidePolicy(WebKitPolicyDecision *decision, WebKitPolicyDecisionType type)
-{
-  if (type == WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION)
-  {
+void WebviewWindow::cookies_got_callback(GObject *source_object, GAsyncResult *result,
+                                 gpointer user_data) {
+  WebKitCookieManager *cookie_manager = WEBKIT_COOKIE_MANAGER(source_object);
+  GList *cookies =
+      webkit_cookie_manager_get_cookies_finish(cookie_manager, result, NULL);
+
+  g_autoptr(FlValue) cookie_list = fl_value_new_list();
+
+  for (GList *l = cookies; l; l = l->next) {
+    SoupCookie *cookie = (SoupCookie *)l->data;
+    g_autoptr(FlValue) cookie_map = fl_value_new_map();
+
+    fl_value_set_string_take(cookie_map, "name",
+                             fl_value_new_string(soup_cookie_get_name(cookie)));
+    fl_value_set_string_take(
+        cookie_map, "value",
+        fl_value_new_string(soup_cookie_get_value(cookie)));
+    fl_value_set_string_take(
+        cookie_map, "domain",
+        fl_value_new_string(soup_cookie_get_domain(cookie)));
+    fl_value_set_string_take(cookie_map, "path",
+                             fl_value_new_string(soup_cookie_get_path(cookie)));
+
+    gdouble expires = g_date_time_get_seconds(soup_cookie_get_expires(cookie));
+
+    if (expires >= 0) {
+      fl_value_set_string_take(cookie_map, "expires",
+                               fl_value_new_float(expires));
+    } else {
+      fl_value_set_string_take(cookie_map, "expires", fl_value_new_null());
+    }
+
+    fl_value_set_string_take(
+        cookie_map, "httpOnly",
+        fl_value_new_bool(soup_cookie_get_http_only(cookie)));
+    fl_value_set_string_take(cookie_map, "secure",
+                             fl_value_new_bool(soup_cookie_get_secure(cookie)));
+    fl_value_set_string_take(cookie_map, "sessionOnly",
+                             fl_value_new_bool(false));
+
+    fl_value_append(cookie_list, cookie_map);
+    soup_cookie_free(cookie);
+  }
+
+  *static_cast<FlValue **>(user_data) = fl_value_ref(cookie_list);
+
+  g_list_free(cookies);
+}
+
+void WebviewWindow::GetAllCookies(FlValue **data) {
+  WebKitWebContext *context =
+      webkit_web_view_get_context(WEBKIT_WEB_VIEW(webview_));
+  WebKitCookieManager *manager = webkit_web_context_get_cookie_manager(context);
+
+  webkit_cookie_manager_get_cookies(
+      manager,
+      "*",
+      NULL,  // No cancellable object
+      (GAsyncReadyCallback)cookies_got_callback, data);
+}
+
+gboolean WebviewWindow::DecidePolicy(WebKitPolicyDecision *decision,
+                                     WebKitPolicyDecisionType type) {
+  if (type == WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION) {
     auto *navigation_decision = WEBKIT_NAVIGATION_POLICY_DECISION(decision);
-    auto *navigation_action = webkit_navigation_policy_decision_get_navigation_action(navigation_decision);
+    auto *navigation_action =
+        webkit_navigation_policy_decision_get_navigation_action(
+            navigation_decision);
     auto *request = webkit_navigation_action_get_request(navigation_action);
     auto *uri = webkit_uri_request_get_uri(request);
     auto *args = fl_value_new_map();
     fl_value_set(args, fl_value_new_string("id"), fl_value_new_int(window_id_));
     fl_value_set(args, fl_value_new_string("url"), fl_value_new_string(uri));
-    fl_method_channel_invoke_method(
-        FL_METHOD_CHANNEL(method_channel_), "onUrlRequested", args,
-        nullptr, nullptr, nullptr);
+    fl_method_channel_invoke_method(FL_METHOD_CHANNEL(method_channel_),
+                                    "onUrlRequested", args, nullptr, nullptr,
+                                    nullptr);
   }
   return false;
 }
 
-void WebviewWindow::EvaluateJavaScript(const char *java_script, FlMethodCall *call)
-{
+void WebviewWindow::EvaluateJavaScript(const char *java_script,
+                                       FlMethodCall *call) {
 #ifdef WEBKIT_OLD_USED
   webkit_web_view_run_javascript(
 #else
@@ -262,8 +309,7 @@ void WebviewWindow::EvaluateJavaScript(const char *java_script, FlMethodCall *ca
       -1, nullptr, nullptr,
 #endif
       nullptr,
-      [](GObject *object, GAsyncResult *result, gpointer user_data)
-      {
+      [](GObject *object, GAsyncResult *result, gpointer user_data) {
         auto *call = static_cast<FlMethodCall *>(user_data);
         GError *error = nullptr;
         auto *js_result =
@@ -273,20 +319,20 @@ void WebviewWindow::EvaluateJavaScript(const char *java_script, FlMethodCall *ca
             webkit_web_view_evaluate_javascript_finish(
 #endif
                 WEBKIT_WEB_VIEW(object), result, &error);
-        if (!js_result)
-        {
-          fl_method_call_respond_error(call, "failed to evaluate javascript.", error->message, nullptr, nullptr);
+        if (!js_result) {
+          fl_method_call_respond_error(call, "failed to evaluate javascript.",
+                                       error->message, nullptr, nullptr);
           g_error_free(error);
-        }
-        else
-        {
+        } else {
           auto *js_value = jsc_value_to_json(
 #ifdef WEBKIT_OLD_USED
               webkit_javascript_result_get_js_value
 #endif
               (js_result),
               0);
-          fl_method_call_respond_success(call, js_value ? fl_value_new_string(js_value) : nullptr, nullptr);
+          fl_method_call_respond_success(
+              call, js_value ? fl_value_new_string(js_value) : nullptr,
+              nullptr);
         }
         g_object_unref(call);
       },

--- a/packages/desktop_webview_window/linux/webview_window.h
+++ b/packages/desktop_webview_window/linux/webview_window.h
@@ -7,20 +7,18 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
+#include <libsoup/soup.h>
 #include <webkit2/webkit2.h>
-#include <functional>
 
+#include <functional>
 #include <string>
 
 class WebviewWindow {
  public:
-  WebviewWindow(
-      FlMethodChannel *method_channel,
-      int64_t window_id,
-      std::function<void()> on_close_callback,
-      const std::string &title, int width, int height,
-      int title_bar_height
-  );
+  WebviewWindow(FlMethodChannel *method_channel, int64_t window_id,
+                std::function<void()> on_close_callback,
+                const std::string &title, int width, int height,
+                int title_bar_height);
 
   virtual ~WebviewWindow();
 
@@ -42,10 +40,12 @@ class WebviewWindow {
 
   void StopLoading();
 
+  void GetAllCookies(FlValue **data);
+
   gboolean DecidePolicy(WebKitPolicyDecision *decision,
                         WebKitPolicyDecisionType type);
 
-  void EvaluateJavaScript(const char *java_script, FlMethodCall* call);
+  void EvaluateJavaScript(const char *java_script, FlMethodCall *call);
 
  private:
   FlMethodChannel *method_channel_;
@@ -57,7 +57,8 @@ class WebviewWindow {
   GtkWidget *window_ = nullptr;
   GtkWidget *webview_ = nullptr;
   GtkBox *box_ = nullptr;
-
+  static void cookies_got_callback(GObject *source_object, GAsyncResult *result,
+                                   gpointer user_data);
 };
 
-#endif //WEBVIEW_WINDOW_LINUX_WEBVIEW_WINDOW_H_
+#endif  // WEBVIEW_WINDOW_LINUX_WEBVIEW_WINDOW_H_

--- a/packages/desktop_webview_window/linux/webview_window.h
+++ b/packages/desktop_webview_window/linux/webview_window.h
@@ -13,6 +13,16 @@
 #include <functional>
 #include <string>
 
+typedef struct {
+    GMainLoop *loop;
+    GList *cookies;
+} CookieData;
+
+void get_cookies_callback(WebKitCookieManager *manager, GAsyncResult *res,
+                          gpointer user_data);
+
+GList *get_cookies_sync(WebKitWebView *web_view);
+
 class WebviewWindow {
  public:
   WebviewWindow(FlMethodChannel *method_channel, int64_t window_id,
@@ -40,7 +50,7 @@ class WebviewWindow {
 
   void StopLoading();
 
-  void GetAllCookies(FlValue **data);
+  FlValue* GetAllCookies();
 
   gboolean DecidePolicy(WebKitPolicyDecision *decision,
                         WebKitPolicyDecisionType type);
@@ -57,8 +67,6 @@ class WebviewWindow {
   GtkWidget *window_ = nullptr;
   GtkWidget *webview_ = nullptr;
   GtkBox *box_ = nullptr;
-  static void cookies_got_callback(GObject *source_object, GAsyncResult *result,
-                                   gpointer user_data);
 };
 
 #endif  // WEBVIEW_WINDOW_LINUX_WEBVIEW_WINDOW_H_

--- a/packages/desktop_webview_window/macos/Classes/DesktopWebviewWindowPlugin.swift
+++ b/packages/desktop_webview_window/macos/Classes/DesktopWebviewWindowPlugin.swift
@@ -272,6 +272,21 @@ public class DesktopWebviewWindowPlugin: NSObject, FlutterPlugin {
       }
       wc.webViewController.evaluateJavaScript(javaScriptString: js, completer: result)
       break
+    case "getAllCookies":
+      guard let argument = call.arguments as? [String: Any?] else {
+        result(FlutterError(code: "0", message: "arg is not map", details: nil))
+        return
+      }
+      guard let viewId = argument["viewId"] as? Int64 else {
+        result(FlutterError(code: "0", message: "param viewId not found", details: nil))
+        return
+      }
+      guard let wc = webviews[viewId] else {
+        result(FlutterError(code: "0", message: "can not find webview for id: \(viewId)", details: nil))
+        return
+      }
+      wc.webViewController.getAllCookies(completer: result)
+      break
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/packages/desktop_webview_window/macos/Classes/WebViewLayoutController.swift
+++ b/packages/desktop_webview_window/macos/Classes/WebViewLayoutController.swift
@@ -182,6 +182,28 @@ class WebViewLayoutController: NSViewController {
     }
   }
 
+  func getAllCookies(completer: @escaping FlutterResult) {
+    self.webView.configuration.websiteDataStore.httpCookieStore.getAllCookies{
+      cookies in
+
+      var cookieDict = [[String: Any]]()
+      for cookie in cookies {
+        cookieDict.append([
+          "name": cookie.name,
+          "value": cookie.value,
+          "domain": cookie.domain,
+          "path": cookie.path,
+          "expiresDate": cookie.expiresDate?.timeIntervalSince1970 ?? NSNull(),
+          "isSecure": cookie.isSecure,
+          "isHTTPOnly": cookie.isHTTPOnly,
+          "isSessionOnly": cookie.isSessionOnly,
+        ])
+      }
+
+      completer(cookieDict)
+    }
+  }
+
   deinit {
     #if DEBUG
       print("\(self) deinited")

--- a/packages/desktop_webview_window/macos/desktop_webview_window.podspec
+++ b/packages/desktop_webview_window/macos/desktop_webview_window.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 
-  s.platform = :osx, '10.12'
+  s.platform = :osx, '10.13'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end

--- a/packages/desktop_webview_window/windows/utils.cc
+++ b/packages/desktop_webview_window/windows/utils.cc
@@ -2,13 +2,13 @@
 // Created by yangbin on 2021/11/11.
 //
 
-#include <windows.h>
-
 #include "utils.h"
+
+#include <windows.h>
 
 #include <memory>
 #include <set>
-
+#include <string>
 
 namespace webview_window {
 
@@ -55,7 +55,8 @@ void ClipOrCenterWindowToMonitor(HWND hwnd, UINT flags) {
   RECT rc;
   GetWindowRect(hwnd, &rc);
   ClipOrCenterRectToMonitor(&rc, flags);
-  SetWindowPos(hwnd, nullptr, rc.left, rc.top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+  SetWindowPos(hwnd, nullptr, rc.left, rc.top, 0, 0,
+               SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 }
 
 bool SetWindowBackgroundTransparent(HWND hwnd) {
@@ -77,9 +78,8 @@ const wchar_t *RegisterWindowClass(LPCWSTR class_name, WNDPROC wnd_proc) {
     window_class.cbClsExtra = 0;
     window_class.cbWndExtra = 0;
     window_class.hInstance = GetModuleHandle(nullptr);
-    window_class.hIcon =
-        LoadIcon(window_class.hInstance, IDI_APPLICATION);
-    window_class.hbrBackground = (HBRUSH) (COLOR_WINDOW + 1);
+    window_class.hIcon = LoadIcon(window_class.hInstance, IDI_APPLICATION);
+    window_class.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
     window_class.lpszMenuName = nullptr;
     window_class.lpfnWndProc = wnd_proc;
     RegisterClass(&window_class);
@@ -94,6 +94,16 @@ void UnregisterWindowClass(LPCWSTR class_name) {
   }
   class_registered_->erase(class_name);
   UnregisterClass(class_name, nullptr);
+}
+
+std::string ConvertLPCWSTRToString(LPCWSTR lpcwszStr) {
+  int strLength = WideCharToMultiByte(CP_UTF8, 0, lpcwszStr, -1, nullptr, 0,
+                                      nullptr, nullptr);
+  std::string str(strLength, 0);
+
+  WideCharToMultiByte(CP_UTF8, 0, lpcwszStr, -1, &str[0], strLength, nullptr,
+                      nullptr);
+  return str;
 }
 
 }  // namespace webview_window

--- a/packages/desktop_webview_window/windows/utils.h
+++ b/packages/desktop_webview_window/windows/utils.h
@@ -8,6 +8,8 @@
 #include <windows.h>
 #include "wil/wrl.h"
 
+#include <string>
+
 namespace webview_window {
 
 const auto MONITOR_CENTER = 0x0001;        // center rect to monitor
@@ -36,6 +38,8 @@ bool SetWindowBackgroundTransparent(HWND hwnd);
 const wchar_t *RegisterWindowClass(LPCWSTR class_name, WNDPROC wnd_proc);
 
 void UnregisterWindowClass(LPCWSTR class_name);
+
+std::string ConvertLPCWSTRToString(LPCWSTR lpcwszStr);
 
 }  // namespace webview_window
 

--- a/packages/desktop_webview_window/windows/web_view.h
+++ b/packages/desktop_webview_window/windows/web_view.h
@@ -49,6 +49,8 @@ class WebView {
 
   void Stop();
 
+  void GetAllCookies(std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> completer);
+
   void openDevToolsWindow();
 
   void ExecuteJavaScript(const std::wstring &javaScript,

--- a/packages/desktop_webview_window/windows/web_view_window_plugin.cc
+++ b/packages/desktop_webview_window/windows/web_view_window_plugin.cc
@@ -1,9 +1,9 @@
 //
 // Created by yangbin on 2021/11/15.
 //
-#include <windows.h>
-
 #include "web_view_window_plugin.h"
+
+#include <windows.h>
 
 #include <map>
 
@@ -37,8 +37,7 @@ void WebviewWindowPlugin::RegisterWithRegistrar(
 }
 
 WebviewWindowPlugin::WebviewWindowPlugin(MethodChannelPtr method_channel)
-    : method_channel_(std::move(method_channel)),
-      windows_() {}
+    : method_channel_(std::move(method_channel)), windows_() {}
 
 WebviewWindowPlugin::~WebviewWindowPlugin() = default;
 
@@ -50,27 +49,37 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "WebView runtime not available");
       return;
     }
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto width = arguments->at(flutter::EncodableValue("windowWidth")).LongValue();
-    auto height = arguments->at(flutter::EncodableValue("windowHeight")).LongValue();
-    auto title = std::get<std::string>(arguments->at(flutter::EncodableValue("title")));
-    auto titleBarHeight = arguments->at(flutter::EncodableValue("titleBarHeight")).LongValue();
-    auto userDataFolder = std::get<std::string>(arguments->at(flutter::EncodableValue("userDataFolderWindows")));
-    auto useWindowPositionAndSize = std::get<bool>(arguments->at(flutter::EncodableValue("useWindowPositionAndSize")));
-    auto openMaximized = std::get<bool>(arguments->at(flutter::EncodableValue("openMaximized")));
-    auto windowPosX = arguments->at(flutter::EncodableValue("windowPosX")).LongValue();
-    auto windowPosY = arguments->at(flutter::EncodableValue("windowPosY")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto width =
+        arguments->at(flutter::EncodableValue("windowWidth")).LongValue();
+    auto height =
+        arguments->at(flutter::EncodableValue("windowHeight")).LongValue();
+    auto title =
+        std::get<std::string>(arguments->at(flutter::EncodableValue("title")));
+    auto titleBarHeight =
+        arguments->at(flutter::EncodableValue("titleBarHeight")).LongValue();
+    auto userDataFolder = std::get<std::string>(
+        arguments->at(flutter::EncodableValue("userDataFolderWindows")));
+    auto useWindowPositionAndSize = std::get<bool>(
+        arguments->at(flutter::EncodableValue("useWindowPositionAndSize")));
+    auto openMaximized =
+        std::get<bool>(arguments->at(flutter::EncodableValue("openMaximized")));
+    auto windowPosX =
+        arguments->at(flutter::EncodableValue("windowPosX")).LongValue();
+    auto windowPosY =
+        arguments->at(flutter::EncodableValue("windowPosY")).LongValue();
 
     auto window_id = next_window_id_;
     auto window = std::make_unique<WebviewWindow>(
         method_channel_, window_id, int(titleBarHeight),
-        [this, window_id]() {
-          windows_.erase(window_id);
-        });
-    std::shared_ptr<flutter::MethodResult<flutter::EncodableValue>> result2(std::move(result));
+        [this, window_id]() { windows_.erase(window_id); });
+    std::shared_ptr<flutter::MethodResult<flutter::EncodableValue>> result2(
+        std::move(result));
     window->CreateAndShow(
-        utf8_to_wide(title), int(height), int(width), utf8_to_wide(userDataFolder),
-        int(windowPosX), int(windowPosY), useWindowPositionAndSize, openMaximized,
+        utf8_to_wide(title), int(height), int(width),
+        utf8_to_wide(userDataFolder), int(windowPosX), int(windowPosY),
+        useWindowPositionAndSize, openMaximized,
         [this, window_id, result(result2)](bool succeed) mutable {
           if (!succeed) {
             result->Error("0", "failed to show window");
@@ -82,11 +91,15 @@ void WebviewWindowPlugin::HandleMethodCall(
     next_window_id_++;
     windows_[window_id] = std::move(window);
   } else if (method_call.method_name() == "launch") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto url = std::get<std::string>(arguments->at(flutter::EncodableValue("url")));
-    auto triggerOnUrlRequestEvent = std::get<bool>(arguments->at(flutter::EncodableValue("triggerOnUrlRequestEvent")));
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto url =
+        std::get<std::string>(arguments->at(flutter::EncodableValue("url")));
+    auto triggerOnUrlRequestEvent = std::get<bool>(
+        arguments->at(flutter::EncodableValue("triggerOnUrlRequestEvent")));
 
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
@@ -96,14 +109,19 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "webview window not ready");
       return;
     }
-    windows_[window_id]->GetWebView()->setTriggerOnUrlRequestedEvent(triggerOnUrlRequestEvent);
+    windows_[window_id]->GetWebView()->setTriggerOnUrlRequestedEvent(
+        triggerOnUrlRequestEvent);
     windows_[window_id]->GetWebView()->Navigate(utf8_to_wide(url));
     result->Success();
-  } else if (method_call.method_name() == "addScriptToExecuteOnDocumentCreated") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+  } else if (method_call.method_name() ==
+             "addScriptToExecuteOnDocumentCreated") {
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto javaScript = std::get<std::string>(arguments->at(flutter::EncodableValue("javaScript")));
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto javaScript = std::get<std::string>(
+        arguments->at(flutter::EncodableValue("javaScript")));
 
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
@@ -113,7 +131,8 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "webview window not ready");
       return;
     }
-    windows_[window_id]->GetWebView()->AddScriptToExecuteOnDocumentCreated(utf8_to_wide(javaScript));
+    windows_[window_id]->GetWebView()->AddScriptToExecuteOnDocumentCreated(
+        utf8_to_wide(javaScript));
     result->Success();
   } else if (method_call.method_name() == "clearAll") {
     std::map<int64_t, std::unique_ptr<WebviewWindow>> local;
@@ -121,10 +140,13 @@ void WebviewWindowPlugin::HandleMethodCall(
     local.clear();
     result->Success();
   } else if (method_call.method_name() == "setApplicationNameForUserAgent") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
 
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto applicationName = std::get<std::string>(arguments->at(flutter::EncodableValue("applicationName")));
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto applicationName = std::get<std::string>(
+        arguments->at(flutter::EncodableValue("applicationName")));
 
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
@@ -134,13 +156,16 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "webview window not ready");
       return;
     }
-    windows_[window_id]->GetWebView()->SetApplicationNameForUserAgent(utf8_to_wide(applicationName));
+    windows_[window_id]->GetWebView()->SetApplicationNameForUserAgent(
+        utf8_to_wide(applicationName));
     result->Success();
   } else if (method_call.method_name() == "isWebviewAvailable") {
     result->Success(flutter::EncodableValue(IsWebViewRuntimeAvailable()));
   } else if (method_call.method_name() == "back") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -152,8 +177,10 @@ void WebviewWindowPlugin::HandleMethodCall(
     windows_[window_id]->GetWebView()->GoBack();
     result->Success();
   } else if (method_call.method_name() == "forward") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -165,9 +192,12 @@ void WebviewWindowPlugin::HandleMethodCall(
     windows_[window_id]->GetWebView()->GoForward();
     result->Success();
   } else if (method_call.method_name() == "setWebviewWindowVisibility") {
-    auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto visible = std::get<bool>(arguments->at(flutter::EncodableValue("visible")));
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto visible =
+        std::get<bool>(arguments->at(flutter::EncodableValue("visible")));
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -179,12 +209,15 @@ void WebviewWindowPlugin::HandleMethodCall(
     windows_[window_id]->setVisibility(visible);
     result->Success();
   } else if (method_call.method_name() == "moveWebviewWindow") {
-    auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
     auto left = std::get<int>(arguments->at(flutter::EncodableValue("left")));
     auto top = std::get<int>(arguments->at(flutter::EncodableValue("top")));
     auto width = std::get<int>(arguments->at(flutter::EncodableValue("width")));
-    auto height = std::get<int>(arguments->at(flutter::EncodableValue("height")));
+    auto height =
+        std::get<int>(arguments->at(flutter::EncodableValue("height")));
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -196,9 +229,12 @@ void WebviewWindowPlugin::HandleMethodCall(
     windows_[window_id]->moveWebviewWindow(left, top, width, height);
     result->Success();
   } else if (method_call.method_name() == "bringToForeground") {
-    auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto maximized = std::get<bool>(arguments->at(flutter::EncodableValue("maximized")));
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto maximized =
+        std::get<bool>(arguments->at(flutter::EncodableValue("maximized")));
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -210,20 +246,24 @@ void WebviewWindowPlugin::HandleMethodCall(
     windows_[window_id]->bringToForeground(maximized);
     result->Success();
   } else if (method_call.method_name() == "getPositionalParameters") {
-      auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-      auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-      if (!windows_.count(window_id)) {
-        result->Error("0", "can not find webview window for id");
-        return;
-      }
-      if (!windows_[window_id]->GetWebView()) {
-        result->Error("0", "webview window not ready");
-        return;
-      }
-      windows_[window_id]->getPositionalParameters(std::move(result));
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    if (!windows_.count(window_id)) {
+      result->Error("0", "can not find webview window for id");
+      return;
+    }
+    if (!windows_[window_id]->GetWebView()) {
+      result->Error("0", "webview window not ready");
+      return;
+    }
+    windows_[window_id]->getPositionalParameters(std::move(result));
   } else if (method_call.method_name() == "reload") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -235,8 +275,10 @@ void WebviewWindowPlugin::HandleMethodCall(
     windows_[window_id]->GetWebView()->Reload();
     result->Success();
   } else if (method_call.method_name() == "stop") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -247,9 +289,25 @@ void WebviewWindowPlugin::HandleMethodCall(
     }
     windows_[window_id]->GetWebView()->Stop();
     result->Success();
+  } else if (method_call.method_name() == "getAllCookies") {
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    if (!windows_.count(window_id)) {
+      result->Error("0", "can not find webview window for id");
+      return;
+    }
+    if (!windows_[window_id]->GetWebView()) {
+      result->Error("0", "webview window not ready");
+      return;
+    }
+    windows_[window_id]->GetWebView()->GetAllCookies(std::move(result));
   } else if (method_call.method_name() == "close") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -257,9 +315,12 @@ void WebviewWindowPlugin::HandleMethodCall(
     windows_.erase(window_id);
     result->Success();
   } else if (method_call.method_name() == "evaluateJavaScript") {
-    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto javascript = std::get<std::string>(arguments->at(flutter::EncodableValue("javaScriptString")));
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto javascript = std::get<std::string>(
+        arguments->at(flutter::EncodableValue("javaScriptString")));
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -268,11 +329,15 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "webview window not ready");
       return;
     }
-    windows_[window_id]->GetWebView()->ExecuteJavaScript(utf8_to_wide(javascript), std::move(result));
+    windows_[window_id]->GetWebView()->ExecuteJavaScript(
+        utf8_to_wide(javascript), std::move(result));
   } else if (method_call.method_name() == "postWebMessageAsString") {
-    auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto webmessage = std::get<std::string>(arguments->at(flutter::EncodableValue("webMessage")));
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto webmessage = std::get<std::string>(
+        arguments->at(flutter::EncodableValue("webMessage")));
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -281,11 +346,15 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "webview window not ready");
       return;
     }
-    windows_[window_id]->GetWebView()->PostWebMessageAsString(utf8_to_wide(webmessage), std::move(result));
+    windows_[window_id]->GetWebView()->PostWebMessageAsString(
+        utf8_to_wide(webmessage), std::move(result));
   } else if (method_call.method_name() == "postWebMessageAsJson") {
-    auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
-    auto webmessage = std::get<std::string>(arguments->at(flutter::EncodableValue("webMessage")));
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto webmessage = std::get<std::string>(
+        arguments->at(flutter::EncodableValue("webMessage")));
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;
@@ -294,10 +363,13 @@ void WebviewWindowPlugin::HandleMethodCall(
       result->Error("0", "webview window not ready");
       return;
     }
-    windows_[window_id]->GetWebView()->PostWebMessageAsJson(utf8_to_wide(webmessage), std::move(result));
+    windows_[window_id]->GetWebView()->PostWebMessageAsJson(
+        utf8_to_wide(webmessage), std::move(result));
   } else if (method_call.method_name() == "openDevToolsWindow") {
-    auto* arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
-    auto window_id = arguments->at(flutter::EncodableValue("viewId")).LongValue();
+    auto *arguments =
+        std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id =
+        arguments->at(flutter::EncodableValue("viewId")).LongValue();
     if (!windows_.count(window_id)) {
       result->Error("0", "can not find webview window for id");
       return;


### PR DESCRIPTION
Closes #125

This PR adds ability to get stored cookies for the webview in all desktop platforms (Windows, MacOS, Linux).
Linux has limited support, as it can only get the webview's active `uri`'s cookies at the moment.

Other platforms has full support to get cookies for all domains available.