### PR TITLE
chore(desktop_drop): use Kotlin 1.7.10 instead of 1.9.10 for compatibility

### DIFF
--- a/packages/desktop_drop/android/build.gradle
+++ b/packages/desktop_drop/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.example.desktop_drop'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()

--- a/packages/desktop_drop/example/android/app/build.gradle
+++ b/packages/desktop_drop/example/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.desktop_drop_example"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/desktop_drop/example/android/build.gradle
+++ b/packages/desktop_drop/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/desktop_drop/example/pubspec.lock
+++ b/packages/desktop_drop/example/pubspec.lock
@@ -115,18 +115,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -155,18 +155,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -320,10 +320,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
Require Kotlin `1.7.10` instead of `1.9.10` for compatibility since we don't use new Kotlin language features.

The Kotlin version set in `packages/desktop_drop/android/build.gradle` represents the minimum Kotlin version for
the user project.

Steps to reproduce:

- Create a new blank Flutter project
- Add `desktop_drop` plugin
- Try to run/build the Android project using `flutter run` or with a Gradle task instead

You will get this build failure:

```
         ┌─ Flutter Fix ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
         │ [!] Your project requires a newer version of the Kotlin Gradle plugin.                                                                                           │
         │ Find the latest version on https://kotlinlang.org/docs/releases.html#release-details, then update /Users/ellet/Developer/projects/alrayada/android/build.gradle: │
         │ ext.kotlin_version = '<latest-version>'                                                                                                                          │
         └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

You will get a different message if you're using a Gradle task to build or run, though both suggest that one of the plugins uses a higher version than the current Kotlin version.

Notice this PR doesn't prevent users from updating to `1.9.10` on their project, though I still suggest using the one that's tested with Flutter, I already tried updating the Android Gradle Plugin and Kotlin version to the latest version on other projects even if I don't use any Android specific code directly on the `android` project, it caused many unexpected release issues and usually the crash or the error messages are generic and doesn't have info or hint to solve the issue.

Those issues won't happen in a blank Flutter project.

Take a look at [What's new in Flutter 3.22](https://medium.com/flutter/whats-new-in-flutter-3-22-fbde6c164fe3) for more details.

![image](https://github.com/user-attachments/assets/60625fe7-d211-496d-b638-d276cbb7c23b)

- For Gradle, it's probably not a requirement, Gradle has strong compatibility for most basic features.
- For the Android Gradle Plugin I suggest downgrading the version as well though it doesn't affect the final Android Gradle Plugin App directly.

Related issues:

- #350
- #155
- #285