### PR TITLE
Fix: Allow developers to enable or disable drag-and-drop visual feedback.

### DIFF
--- a/packages/desktop_drop/lib/src/channel.dart
+++ b/packages/desktop_drop/lib/src/channel.dart
@@ -37,22 +37,18 @@ class DesktopDrop {
     });
   }
 
-  Future<bool> startAccessingSecurityScopedResource(
-      {required Uint8List bookmark}) async {
+  Future<bool> startAccessingSecurityScopedResource({required Uint8List bookmark}) async {
     Map<String, dynamic> resultMap = Map();
     resultMap["apple-bookmark"] = bookmark;
-    final bool? result = await _channel.invokeMethod(
-        "startAccessingSecurityScopedResource", resultMap);
+    final bool? result = await _channel.invokeMethod("startAccessingSecurityScopedResource", resultMap);
     if (result == null) return false;
     return result;
   }
 
-  Future<bool> stopAccessingSecurityScopedResource(
-      {required Uint8List bookmark}) async {
+  Future<bool> stopAccessingSecurityScopedResource({required Uint8List bookmark}) async {
     Map<String, dynamic> resultMap = Map();
     resultMap["apple-bookmark"] = bookmark;
-    final bool result = await _channel.invokeMethod(
-        "stopAccessingSecurityScopedResource", resultMap);
+    final bool result = await _channel.invokeMethod("stopAccessingSecurityScopedResource", resultMap);
     return result;
   }
 
@@ -108,8 +104,7 @@ class DesktopDrop {
       case "performOperation_linux":
         // gtk notify 'exit' before 'performOperation'.
         final text = (call.arguments as List<dynamic>)[0] as String;
-        final offset = ((call.arguments as List<dynamic>)[1] as List<dynamic>)
-            .cast<double>();
+        final offset = ((call.arguments as List<dynamic>)[1] as List<dynamic>).cast<double>();
         final paths = const LineSplitter().convert(text).map((e) {
           try {
             return Uri.tryParse(e)?.toFilePath() ?? '';
@@ -124,11 +119,7 @@ class DesktopDrop {
         ));
         break;
       case "performOperation_web":
-        final results = (call.arguments as List)
-            .cast<Map>()
-            .map((e) => WebDropItem.fromJson(e.cast<String, dynamic>()))
-            .map((e) => e.toDropItem())
-            .toList();
+        final results = (call.arguments as List).cast<Map>().map((e) => WebDropItem.fromJson(e.cast<String, dynamic>())).map((e) => e.toDropItem()).toList();
         _notifyEvent(
           DropDoneEvent(location: _offset ?? Offset.zero, files: results),
         );
@@ -153,5 +144,13 @@ class DesktopDrop {
   void removeRawDropEventListener(RawDropListener listener) {
     assert(_listeners.contains(listener));
     _listeners.remove(listener);
+  }
+
+  void enableDragDropVisualFeedback() {
+    _channel.invokeMethod('enable', {});
+  }
+
+  void disableDragDropVisualFeedback() {
+    _channel.invokeMethod('disable', {});
   }
 }

--- a/packages/desktop_drop/macos/Classes/DesktopDropPlugin.swift
+++ b/packages/desktop_drop/macos/Classes/DesktopDropPlugin.swift
@@ -35,9 +35,22 @@ public class DesktopDropPlugin: NSObject, FlutterPlugin {
     d.registerForDraggedTypes(NSFilePromiseReceiver.readableDraggedTypes.map { NSPasteboard.PasteboardType($0) })
     d.registerForDraggedTypes([NSPasteboard.PasteboardType.fileURL])
 
-    vc.view.addSubview(d)
+    // If the DropTarget be added from here, drag-and-drop visual feedback will be implemented immediately.
+    // This will causes the cursor to change to `+` shape and appear as if files can be dropped, even though the flutter code does not include a DropTarget widget.
+    // vc.view.addSubview(d)
 
     registrar.addMethodCallDelegate(instance, channel: channel)
+
+    // Instead, it should be added only when needed and removed otherwise.
+    // `channel.setMethodCallHandler` should be implemented after `registrar.addMethodCallDelegate`
+    channel.setMethodCallHandler { call, result in
+      if call.method == "enable"{
+        vc.view.addSubview(d)
+      }else if (call.method == "disable"){
+        d.removeFromSuperview()
+      }
+      result(nil)
+    }
   }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult){


### PR DESCRIPTION
### Summary
- This Pull Request addresses an issue with the drag-and-drop visual feedback in the `desktop_drop` package.
- **Drag-and-drop visual feedback** refers to the feature where the mouse cursor changes to a `+` shape when files are dragged over the app window, and files appear to be dropped onto the app window when the mouse button is released.

### Issue
- In applications without drag-and-drop functionality, the mouse cursor does not change to a `+` shape, and files return to their original position when the mouse button is released.
- With the `desktop_drop` package implemented, the drag-and-drop visual feedback is activated even if the `DropTarget` widget is not present. This can mislead users into thinking that the app supports drag-and-drop functionality when it does not.

### Details
- This update allows developers to control whether drag-and-drop visual feedback is enabled or disabled.

### Usage
- To enable or disable drag-and-drop visual feedback, use the following code in your widget:

```dart
@override
void initState() {
  DesktopDrop.instance.enableDragDropVisualFeedback();
  super.initState();
}

@override
void dispose() {
  DesktopDrop.instance.disableDragDropVisualFeedback();
  super.dispose();
}

### Limitations
- This implementation applies only to macOS. Support for Linux and Windows is not included.
- The feedback is applied at the page level. Consideration is needed for implementing this at a more granular level within parts of a page.