### PR TITLE
feat(pasteboard): Add Android setup instructions to README

### DIFF
--- a/packages/pasteboard/README.md
+++ b/packages/pasteboard/README.md
@@ -2,19 +2,20 @@
 
 [![Pub](https://img.shields.io/pub/v/pasteboard.svg)](https://pub.dev/packages/pasteboard)
 
-A flutter plugin which could read image,files from clipboard and write files to clipboard.
+A Flutter plugin that allows reading images and files from the clipboard and writing files to the clipboard.
 
-|         |     |
-|---------|-----|
-| Windows | ✅   |
-| Linux   | ✅   |
-| macOS   | ✅   |
-| iOS     | ✅   |
-| Web     | ✅   |
+| Platform | Supported | Requires Setup |
+|----------|---------- |--------------- |
+| Windows  | ✅        | No             |
+| Linux    | ✅        | No             |
+| macOS    | ✅        | No             |
+| iOS      | ✅        | No             |
+| Web      | ✅        | No             |
+| Android  | ✅        | Yes            |
 
 ## Getting Started
 
-1. add `package:pasteboard` to `pubspec.yaml`
+1. Add `package:pasteboard` to `pubspec.yaml`:
 
    ```yaml
    dependencies:
@@ -39,6 +40,42 @@ A flutter plugin which could read image,files from clipboard and write files to 
      print(imageBytes?.length);
    }
    ```
+
+## Android Setup
+To use this package on Android without errors, follow these steps:
+
+1. Add the following `<provider>` entry inside the `<application>` tag in your AndroidManifest.xml (`android/app/src/main/AndroidManifest.xml`):
+
+```xml
+<provider
+    android:name="androidx.core.content.FileProvider"
+    android:authorities="${applicationId}.provider"
+    android:exported="false"
+    android:grantUriPermissions="true">
+    <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/provider_paths" />
+</provider>
+```
+2. Create the file `provider_paths.xml` at `android/app/src/main/res/xml/provider_paths.xml` with the following content:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path
+        name="external_files"
+        path="." />
+</paths>
+```
+
+### Common Issues
+If these steps are not followed, you may encounter the following runtime error:
+
+```
+Couldn't find meta-data for provider with authority
+```
+
+Make sure the `<provider>` entry is correctly added to the `AndroidManifest.xml` and that the `provider_paths.xml` file exists in the correct location.
 
 ## License
 


### PR DESCRIPTION
This PR updates the README.md to include the necessary setup steps for using pasteboard on Android. Without these steps, users may encounter a runtime error:

```
Couldn't find meta-data for provider with authority
```
## Changes
- Added a **"Requires Setup"** column to the platform support table.
- Included a new **"Android Setup"** section explaining the required changes to `AndroidManifest.xml` and `provider_paths.xml`.
- Added a **"Common Issues"** section to help troubleshoot common errors.

## 📱 Why is this needed?
The recent PR adding Android support requires additional configuration in `AndroidManifest.xml` and a new XML file for `FileProvider`. This update ensures that users can integrate `pasteboard` on Android smoothly.

## ✅ Checklist
- [x] Updated README.md with Android setup instructions.
 - [x] Verified that the instructions are correct and complete.
 
Let me know if any changes are needed. 🚀