### PR TITLE
[desktop_webview_window] macos close webview process

### DIFF
--- a/packages/desktop_webview_window/macos/Classes/WebviewWindowController.swift
+++ b/packages/desktop_webview_window/macos/Classes/WebviewWindowController.swift
@@ -71,6 +71,7 @@ class WebviewWindowController: NSWindowController {
     webViewController.destroy()
     webviewPlugin = nil
     window?.delegate = nil
+    window?.close()
     window = nil
   }
 


### PR DESCRIPTION
actually close webview when user calls `close()`, so window doesn't hang around longer than required