### PR TITLE
fix(win_toast): build fail on latest visual studio

### DIFF
--- a/packages/win_toast/windows/CMakeLists.txt
+++ b/packages/win_toast/windows/CMakeLists.txt
@@ -32,9 +32,11 @@ apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+  
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin windowsapp)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(win_toast_bundled_libraries


### PR DESCRIPTION
Error logs:

`win_toast_plugin.obj : error LNK2019: unresolved external symbol WINRT_IMPL_RoGetActivationFactory referenced in function "struct winrt::hresult __cdecl winrt::impl::get_runtime_activation_factory_impl<1>(struct winrt::param::hstring const &,struct winrt::guid const &,void * *)" (??$get_runtime_activation_factory_impl@$00@impl@winrt@@YA?AUhresult@1@AEBUhstring@param@1@AEBUguid@1@PEAPEAX@Z) [D:\a\1\s\build\windows\x64\plugins\win_toast\win_toast_plugin.vcxproj]
DesktopNotificationManagerCompat.obj : error LNK2001: unresolved external symbol WINRT_IMPL_RoGetActivationFactory [D:\a\1\s\build\windows\x64\plugins\win_toast\win_toast_plugin.vcxproj]
win_toast_plugin.obj : error LNK2019: unresolved external symbol WINRT_IMPL_RoOriginateLanguageException referenced in function "private: void __cdecl winrt::hresult_error::originate(struct winrt::hresult,void *,struct winrt::impl::slim_source_location const &)" (?originate@hresult_error@winrt@@AEAAXUhresult@2@PEAXAEBUslim_source_location@impl@2@@Z) [D:\a\1\s\build\windows\x64\plugins\win_toast\win_toast_plugin.vcxproj]
DesktopNotificationManagerCompat.obj : error LNK2001: unresolved external symbol WINRT_IMPL_RoOriginateLanguageException [D:\a\1\s\build\windows\x64\plugins\win_toast\win_toast_plugin.vcxproj]
D:\a\1\s\build\windows\x64\plugins\win_toast\Release\win_toast_plugin.dll : fatal error LNK1120: 2 unresolved externals [D:\a\1\s\build\windows\x64\plugins\win_toast\win_toast_plugin.vcxproj]
`