### PR TITLE
[desktop_multi_window] bug: mac NSWindow delegate conflict, To preven…

### DIFF
--- a/packages/desktop_multi_window/macos/Classes/MultiWindowManager.swift
+++ b/packages/desktop_multi_window/macos/Classes/MultiWindowManager.swift
@@ -61,11 +61,13 @@ class MultiWindowManager {
       debugPrint("window \(windowId) not exists.")
       return
     }
+    onClose(windowId)
     window.close()
   }
 
   func closeAll() {
     windows.forEach { _, value in
+      onClose(windowId)
       value.close()
     }
   }


### PR DESCRIPTION
[desktop_multi_window] bug: mac NSWindow delegate conflict, To prevent the flutter engine from being shut down after the NSWindow delegate is reset by other components (such as window_manager), shut down the flutter engine first when shutting down.