### PR TITLE
[desktop_drop] macOS: robust multi-source drag & drop (file URLs, promises, directories) — 0.7.0

### DIFF
--- a/packages/desktop_drop/CHANGELOG.md
+++ b/packages/desktop_drop/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.7.0
+
+[macOS] Robust multi-source drag & drop.
+
+* Prefer `public.file-url` / legacy filename arrays when present; fall back to
+  `NSFilePromiseReceiver` (file promises) otherwise.
+* Handle directories (`isDirectory`) and surface as `DropItemDirectory`.
+* Add `fromPromise` to `DropItem` so apps can distinguish promise-based drops.
+* Generate security-scoped bookmarks only for paths outside the app container
+  (skip/empty for promise files in `.../tmp/Drops/...`).
+* Per-drop unique destination for promised files to avoid name collisions.
+* Thread-safe collection of drop results when receiving promises.
+* Dart guards: no-op `start/stopAccessingSecurityScopedResource` on empty
+  bookmarks.
+* Bump macOS minimum to 10.13 (SPM/Podspec).
+
 ## 0.6.1
 
 * Fix desktop_drop Linux snap build failure due to missing stdlib.h include (#425)

--- a/packages/desktop_drop/macos/desktop_drop.podspec
+++ b/packages/desktop_drop/macos/desktop_drop.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.source_files     = 'desktop_drop/Sources/desktop_drop/**/*.{h,m,swift}'
   s.dependency 'FlutterMacOS'
 
-  s.platform = :osx, '10.11'
+  s.platform = :osx, '10.13'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end

--- a/packages/desktop_drop/macos/desktop_drop/Package.swift
+++ b/packages/desktop_drop/macos/desktop_drop/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "desktop_drop",
     platforms: [
-        .macOS("10.11")
+        .macOS("10.13")
     ],
     products: [
         .library(name: "desktop-drop", targets: ["desktop_drop"])

--- a/packages/desktop_drop/pubspec.yaml
+++ b/packages/desktop_drop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_drop
 description: A plugin which allows user dragging files to your flutter desktop applications.
-version: 0.6.1
+version: 0.7.0
 homepage: https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_drop
 
 environment:
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
### Summary

This PR upgrades the macOS implementation to handle real-world drag sources reliably and predictably:

solves [#433](https://github.com/MixinNetwork/flutter-plugins/issues/433)

* Prefer **`public.file-url`** and **`NSFilenamesPboardType`** (legacy filename arrays) when present.
* Fall back to **`NSFilePromiseReceiver`** for sources like VS Code/Electron that deliver **file promises**.
* Correctly detect **directories** and surface them as `DropItemDirectory`.
* Add a first-class `fromPromise` flag on `DropItem` so apps can tailor UX when the original path is unavailable.
* Create **security-scoped bookmarks only** for paths **outside** the app container/tmp.
* Use a **per-drop unique destination** for promised files to avoid name collisions.
* Make promise reception **thread-safe** (guard shared state with a lock).
* Guard Dart `start/stopAccessingSecurityScopedResource` calls when the bookmark is empty.

Version bump: **0.7.0**. Minimum macOS set to **10.13** (SwiftPM/Podspec).

---

### Motivation & context

Different apps advertise drag data differently:

* Finder/JetBrains usually supply **file URLs** (true original paths).
* VS Code/Electron often supply **file promises** (no original path; the receiver chooses a destination and the source writes bytes there).

Previously, multi-file drags could be incomplete, directory drops weren’t differentiated, and promise handling could yield race conditions and unnecessary bookmark attempts. This PR addresses those issues and codifies behavior so plugin consumers can build robust UX across sources.

---

### What’s changed (highlights)

* **macOS (Swift)**

  * Register all relevant pasteboard types (file URLs, filenames array, file promises).
  * Prefer URLs/legacy arrays; only **fallback** to promises.
  * Add **per-drop `Drops/<timestamp>`** destination; safer timestamp format.
  * **Thread-safe** aggregation of results (lock around `seen`/`items`).
  * Generate security-scoped bookmarks **only** for paths outside container/tmp; `NSNull` otherwise.
  * Include `isDirectory` and `fromPromise` in channel payloads.

* **Dart**

  * `DropItem` now has `fromPromise` and documented `extraAppleBookmark`.
  * Map `isDirectory` → `DropItemDirectory`.
  * Safeguard `start/stopAccessingSecurityScopedResource` against empty bookmarks (no-ops).
  * Minor docs in code.

* **Meta**

  * `pubspec.yaml`: version → `0.7.0`.
  * `Package.swift`/Podspec: macOS min → `10.13`.
  * `CHANGELOG.md` updated.

---

### API changes for consumers

* New: `DropItem.fromPromise` (bool).

  * `true` means the item came via a file promise and was written into the plugin’s `Drops/<timestamp>` folder. The original source path is **not available** by design.
* Existing: `DropItem.extraAppleBookmark` (Uint8List?) is **often null/empty** for promise files and **non-empty** for file URLs outside the app container.
* Behavior: `DesktopDrop.start/stopAccessingSecurityScopedResource` **no-op** when bookmark is empty.

**Typical usage:**

```dart
for (final item in details.files) {
  if (item.fromPromise) {
    // Working from a delivered copy under Drops/<timestamp>/...
    // No original path to reveal; read directly.
  } else if ((item.extraAppleBookmark?.isNotEmpty ?? false)) {
    await DesktopDrop.instance.startAccessingSecurityScopedResource(
      bookmark: item.extraAppleBookmark!,
    );
    try {
      // Read the file at item.path
    } finally {
      await DesktopDrop.instance.stopAccessingSecurityScopedResource(
        bookmark: item.extraAppleBookmark!,
      );
    }
  } else {
    // File URL inside container/tmp or non-macOS; just read it.
  }
}
```

---

### Backward compatibility

* Additive Dart fields; existing apps continue to work.
* Promised files now land under `Drops/<timestamp>` (still under tmp); previous behavior used a shared `Drops` folder — this reduces collisions but changes the exact path. Consumers reading from the returned `path` are unaffected.

---

### Known limitations (documented)

* For **file promises**, macOS does **not** expose the original source path. This is expected. The plugin now marks such items with `fromPromise = true` and provides a stable, readable copy path.

---

### Testing

**Manual matrix**

* Finder → single/multi files: all items reported; real paths; bookmarks present.
* JetBrains/IntelliJ → multi files: all items reported; real paths; bookmarks present.
* VS Code/Electron → single/multi: files in `Drops/<timestamp>/...`; `fromPromise = true`; bookmarks empty; bytes readable.
* Folder drops (Finder): `DropItemDirectory` surfaced; `isDirectory = true`.
* Sandboxed build: reading promise files within container works without bookmarks; reading external files works with bookmarks.

**Edge cases**

* Mix of URLs and promises: URLs win; promises processed only when URLs absent.
* Duplicate items from mixed pasteboard types: de-duplicated by path (thread-safe).