### PR TITLE
Win32: Center windows within the work area, taking occlusions like the Task Bar into account

### DIFF
--- a/packages/desktop_multi_window/windows/base_flutter_window.cc
+++ b/packages/desktop_multi_window/windows/base_flutter_window.cc
@@ -23,7 +23,7 @@ void CenterRectToMonitor(LPRECT prc) {
   mi.cbSize = sizeof(mi);
   GetMonitorInfo(hMonitor, &mi);
 
-  rc = mi.rcMonitor;
+  rc = mi.rcWork;
 
   prc->left = rc.left + (rc.right - rc.left - w) / 2;
   prc->top = rc.top + (rc.bottom - rc.top - h) / 2;


### PR DESCRIPTION
On Windows, things like the Task Bar permanently reserve a part of the area within the bounds of a monitor. The Task Bar is "always on top", so if you try to force your window into some of its space, your window will simply be covered. The `Center` method in `BaseFlutterWindow` in the Win32 back-end (`base_flutter_window.cc`) computes the new bounds without taking this into account. For instance, if your task bar is occupying 40 pixels at the bottom of a 1920x1080 display, and you center a window that is 1,000 pixels tall, it will be placed so that there is 460 pixels above the window and 460 pixels below it -- but 40 out of those 460 below it are actually occupied by the Task Bar. If the window is 1040 pixels tall, then the `Center` function will place it so that there are 40 pixels above it, but the bottom edge is *touching* the Task Bar. If the window is more than 1040 pixels tall, then some of it will be hidden behind the Task Bar.

The problem gets worse if the task bar is resized and uses more space (if it is docked to the left or right, it uses considerably more space).

This PR solves the problem. It's a quick one-liner. When you call `GetMonitorInfo` to get information about a monitor's placement in the virtual desktop space, one `RECT` called `rcMonitor` gives you the pixel coordinates of the raw boundaries of the monitor, but there's another `RECT` called `rcWork` that gives you the "work area" -- the space left after the Task Bar and anything else docked to the edge have been taken into account. So, the calculation is changed to use `rcWork` instead of `rcMonitor`.