### PR TITLE
[desktop_drop]: `on_focus_in_event` should return `gboolean`

### DIFF
--- a/packages/desktop_drop/linux/desktop_drop_plugin.cc
+++ b/packages/desktop_drop/linux/desktop_drop_plugin.cc
@@ -77,11 +77,11 @@ static void desktop_drop_plugin_init(DesktopDropPlugin *self) {
   }
 }
 
-static void on_focus_in_event(GtkWidget *widget, GdkEventFocus *event, gpointer user_data) {
+static gboolean on_focus_in_event(GtkWidget *widget, GdkEventFocus *event, gpointer user_data) {
   if (isKDE) {
     ignoreNext = TRUE;
   }
-  return;
+  return FALSE;
 }
 
 static void method_call_cb(FlMethodChannel *channel, FlMethodCall *method_call,


### PR DESCRIPTION
See: https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html

Fixes: https://github.com/Chevey339/kelivo/issues/304