### PR TITLE
[desktop_drop_web] fix: loop readEntries() to retrieve all directory children on web

### DIFF
--- a/packages/desktop_drop/lib/desktop_drop_web.dart
+++ b/packages/desktop_drop/lib/desktop_drop_web.dart
@@ -27,18 +27,32 @@ class DesktopDropWeb {
     pluginInstance._registerEvents();
   }
 
+  // The FileSystemDirectoryReader.readEntries() Web API returns at most 100
+  // entries per call by spec. To retrieve all children of a directory, the
+  // caller must call readEntries() repeatedly until it returns an empty batch.
+  // Calling it only once silently truncates directories with >100 files.
+  // See: https://wicg.github.io/entries-api/#dom-filesystemdirectoryreader-readentries
+  Future<List<dynamic>> _readAllEntries(
+      web.FileSystemDirectoryReader reader) async {
+    final allEntries = <dynamic>[];
+    while (true) {
+      final completer = Completer<List<dynamic>>();
+      reader.readEntries((JSArray<web.FileSystemEntry> batch) {
+        completer.complete(batch.toDart);
+      }.toJS);
+      final batch = await completer.future;
+      if (batch.isEmpty) break;
+      allEntries.addAll(batch);
+    }
+    return allEntries;
+  }
+
   Future<WebDropItem> _entryToWebDropItem(web.FileSystemEntry entry) async {
     if (entry.isDirectory == true) {
       entry = entry as web.FileSystemDirectoryEntry;
       final web.FileSystemDirectoryReader reader = entry.createReader();
-      Completer entriesCompleter = Completer<List<dynamic>>();
-      entriesCallBack(JSArray<web.FileSystemEntry> sub) {
-        entriesCompleter.complete(sub.toDart);
-      }
 
-      reader.readEntries(entriesCallBack.toJS);
-
-      final List<dynamic> entries = await entriesCompleter.future;
+      final List<dynamic> entries = await _readAllEntries(reader);
 
       final children = await Future.wait(
         entries.map((e) => _entryToWebDropItem(e)),


### PR DESCRIPTION
## Problem

When a user drags a directory (or multiple directories) onto a \`DropTarget\` on the **web** platform, only a subset of the files inside are reported — typically the first batch up to ~100 entries, with the remainder silently discarded.

## Root Cause

\`_entryToWebDropItem\` called \`FileSystemDirectoryReader.readEntries()\` exactly **once** per directory. The [Entries API spec](https://wicg.github.io/entries-api/#dom-filesystemdirectoryreader-readentries) states:

> The readEntries() method, when invoked, returns at most 100 entries. The caller **must** call readEntries() repeatedly until it returns an empty list to guarantee all entries are retrieved.

Because the previous code only issued a single call, any directory containing more than 100 children would be silently truncated.

## Fix

Extracted a \`_readAllEntries()\` helper that calls \`readEntries()\` in a loop, accumulating results until an empty batch signals completion. \`_entryToWebDropItem\` now delegates to this helper instead of calling \`readEntries()\` directly.

## Testing

- Drag a folder containing **>100 files** onto a \`DropTarget\` in a Flutter web app — all files are now delivered to the \`onDragDone\` callback.
- Drag a folder with <100 files — behaviour unchanged.
- Drag individual files (no directory) — behaviour unchanged.