### PR TITLE
Fix Windows fullscreen for multi-window Flutter views

### DIFF
--- a/packages/desktop_multi_window/windows/flutter_window.cc
+++ b/packages/desktop_multi_window/windows/flutter_window.cc
@@ -18,6 +18,9 @@ bool FlutterWindow::OnCreate() {
   RECT frame = GetClientArea();
 
   flutter::DartProject project(L"data");
+  // Avoid Windows fullscreen freezes in recent Flutter engines when
+  // window_manager changes styles from a platform-channel call.
+  project.set_ui_thread_policy(flutter::UIThreadPolicy::RunOnSeparateThread);
   std::vector<std::string> entrypoint_args = {"multi_window", id_,
                                               window_argument_};
   project.set_dart_entrypoint_arguments(entrypoint_args);

--- a/packages/desktop_multi_window/windows/win32_window.cpp
+++ b/packages/desktop_multi_window/windows/win32_window.cpp
@@ -18,6 +18,8 @@ namespace {
 constexpr const wchar_t kWindowClassName[] =
     L"FLUTTER_MULTI_WINDOW_WIN32_WINDOW";
 
+constexpr UINT kResizeChildContentMessage = WM_APP + 0x3D1;
+
 /// Registry key for app theme preference.
 ///
 /// A value of 0 indicates apps should use dark mode. A non-zero or missing
@@ -207,18 +209,21 @@ Win32Window::MessageHandler(HWND hwnd,
 
       SetWindowPos(hwnd, nullptr, newRectSize->left, newRectSize->top, newWidth,
                    newHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+      QueueChildContentResize();
 
       return 0;
     }
     case WM_SIZE: {
-      RECT rect = GetClientArea();
-      if (child_content_ != nullptr) {
-        // Size and position the child window.
-        MoveWindow(child_content_, rect.left, rect.top, rect.right - rect.left,
-                   rect.bottom - rect.top, TRUE);
-      }
+      ResizeChildContent();
       return 0;
     }
+    case WM_WINDOWPOSCHANGED:
+      QueueChildContentResize();
+      break;
+    case kResizeChildContentMessage:
+      child_resize_pending_ = false;
+      ResizeChildContent();
+      return 0;
 
     case WM_ACTIVATE:
       if (child_content_ != nullptr) {
@@ -254,10 +259,7 @@ Win32Window* Win32Window::GetThisFromHandle(HWND const window) noexcept {
 void Win32Window::SetChildContent(HWND content) {
   child_content_ = content;
   SetParent(content, window_handle_);
-  RECT frame = GetClientArea();
-
-  MoveWindow(content, frame.left, frame.top, frame.right - frame.left,
-             frame.bottom - frame.top, true);
+  ResizeChildContent();
 
   SetFocus(child_content_);
 }
@@ -274,6 +276,26 @@ HWND Win32Window::GetHandle() {
 
 void Win32Window::SetQuitOnClose(bool quit_on_close) {
   quit_on_close_ = quit_on_close;
+}
+
+void Win32Window::QueueChildContentResize() {
+  if (window_handle_ == nullptr || child_content_ == nullptr ||
+      child_resize_pending_) {
+    return;
+  }
+  child_resize_pending_ = true;
+  if (!PostMessage(window_handle_, kResizeChildContentMessage, 0, 0)) {
+    child_resize_pending_ = false;
+  }
+}
+
+void Win32Window::ResizeChildContent() {
+  if (child_content_ == nullptr) {
+    return;
+  }
+  RECT frame = GetClientArea();
+  MoveWindow(child_content_, frame.left, frame.top, frame.right - frame.left,
+             frame.bottom - frame.top, TRUE);
 }
 
 bool Win32Window::OnCreate() {

--- a/packages/desktop_multi_window/windows/win32_window.h
+++ b/packages/desktop_multi_window/windows/win32_window.h
@@ -90,7 +90,11 @@ class Win32Window {
   // Update the window frame's theme to match the system theme.
   static void UpdateTheme(HWND const window);
 
+  void QueueChildContentResize();
+  void ResizeChildContent();
+
   bool quit_on_close_ = false;
+  bool child_resize_pending_ = false;
 
   // window handle for top level window.
   HWND window_handle_ = nullptr;


### PR DESCRIPTION
## Summary

Fixes a Windows fullscreen rendering issue in `desktop_multi_window` sub-windows when another plugin, such as `window_manager`, changes the native window style and size for fullscreen.

The observed failure was that the Flutter content stayed at its previous windowed size in the top-left corner after entering fullscreen, while the rest of the monitor could show stale/underlying desktop windows instead of the app background. In some fullscreen paths this could also hang or freeze the app.

Branch: `bugfix/windows-fullscreen-patch`

## What Changed

- Set Windows sub-window Flutter engines to `flutter::UIThreadPolicy::RunOnSeparateThread`.
- Refactored child Flutter view resizing into `ResizeChildContent()`.
- Added a deferred child resize message after `WM_WINDOWPOSCHANGED` and `WM_DPICHANGED`, so the hosted Flutter child is re-sized to the updated client area after native fullscreen/window-position changes settle.
- Added a small pending-message guard so resize messages are coalesced and the flag is cleared if `PostMessage` fails.

Touched files:

- `packages/desktop_multi_window/windows/flutter_window.cc`
- `packages/desktop_multi_window/windows/win32_window.cpp`
- `packages/desktop_multi_window/windows/win32_window.h`

## Why

`desktop_multi_window` creates each sub-window with its own native parent window and hosted Flutter child view. On Windows, entering fullscreen through `window_manager.setFullScreen()` changes the top-level window style and position/size. The existing `WM_SIZE` path resized the child in normal cases, but fullscreen style/position transitions could leave the child surface at the old windowed bounds for the frame that mattered, producing a top-left-only Flutter view.

The deferred resize keeps the normal immediate `WM_SIZE` handling, while also scheduling a follow-up resize after native window-position changes. That avoids a force-refresh style workaround and makes the child view match the final fullscreen client area.

The separate UI thread policy avoids recent Windows fullscreen freezes seen when fullscreen style changes are driven through platform-channel calls.

## Validation

I've verified this patch in my flutter app and it works well.

## Notes

This patch is intentionally Windows-only and scoped to the `desktop_multi_window` native sub-window wrapper. It does not change Dart APIs or behavior on macOS/Linux.