### PR TITLE
mixin_logger: support Swift Package Manager on iOS

### DIFF
--- a/packages/mixin_logger/CHANGELOG.md
+++ b/packages/mixin_logger/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.4
+* support Swift Package Manager on iOS
+
 ## 0.1.3
 * support android 15 16k page size
 

--- a/packages/mixin_logger/ios/mixin_logger/Package.swift
+++ b/packages/mixin_logger/ios/mixin_logger/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "mixin_logger",
+    platforms: [
+        .iOS("12.0")
+    ],
+    products: [
+        // `mixin_logger` is an FFI plugin whose Dart bindings load the native
+        // code from a dynamic framework, so the product is built as a dynamic
+        // library rather than being statically linked into the app binary.
+        //
+        // The product is named `mixin-logger` (with a hyphen) because Flutter's
+        // generated `FlutterGeneratedPluginSwiftPackage` references plugin
+        // products by the package name with underscores replaced by hyphens.
+        // The framework SPM builds is therefore `mixin-logger.framework`; the
+        // Dart loader in `lib/src/write_to_file_ffi.dart` accepts both this name
+        // and the CocoaPods `mixin_logger.framework` name.
+        .library(name: "mixin-logger", type: .dynamic, targets: ["mixin_logger"])
+    ],
+    targets: [
+        .target(
+            name: "mixin_logger"
+        )
+    ]
+)

--- a/packages/mixin_logger/ios/mixin_logger/Sources/mixin_logger/include/mixin_logger/mixin_logger.h
+++ b/packages/mixin_logger/ios/mixin_logger/Sources/mixin_logger/include/mixin_logger/mixin_logger.h
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#if _WIN32
+#include <windows.h>
+#else
+
+#include <pthread.h>
+#include <unistd.h>
+
+#endif
+
+#if _WIN32
+#define FFI_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FFI_PLUGIN_EXPORT
+#endif
+
+#ifdef __cplusplus
+extern "C" {  // only need to export C interface if
+// used by C++ source code
+#endif
+
+
+FFI_PLUGIN_EXPORT intptr_t
+mixin_logger_init(const char *dir, intptr_t max_file_size, intptr_t max_file_count, const char *file_leading);
+
+FFI_PLUGIN_EXPORT intptr_t mixin_logger_set_file_leading(const char *file_leading);
+
+FFI_PLUGIN_EXPORT intptr_t mixin_logger_write_log(const char *log);
+
+#ifdef __cplusplus
+}
+#endif

--- a/packages/mixin_logger/ios/mixin_logger/Sources/mixin_logger/mixin_logger.cpp
+++ b/packages/mixin_logger/ios/mixin_logger/Sources/mixin_logger/mixin_logger.cpp
@@ -1,0 +1,8 @@
+// Relative import to be able to reuse the C sources.
+//
+// Swift Package Manager (like CocoaPods) does not support referencing source
+// files outside of the package directory, so this forwarder relatively imports
+// the shared implementation in `../src` so that the C sources can be shared
+// among all target platforms. See the comment in ../mixin_logger.podspec for
+// more information about the equivalent CocoaPods setup.
+#include "../../../../src/mixin_logger.cpp"

--- a/packages/mixin_logger/lib/src/write_to_file_ffi.dart
+++ b/packages/mixin_logger/lib/src/write_to_file_ffi.dart
@@ -11,7 +11,19 @@ const String _libName = 'mixin_logger';
 /// The dynamic library in which the symbols for [MixinLoggerBindings] can be found.
 final DynamicLibrary _dylib = () {
   if (Platform.isMacOS || Platform.isIOS) {
-    return DynamicLibrary.open('$_libName.framework/$_libName');
+    // The native code ships as a dynamic framework. With CocoaPods the
+    // framework is named after the pod (`mixin_logger`); with Swift Package
+    // Manager it is named after the SPM product (`mixin-logger`, because
+    // Flutter references plugin products with underscores replaced by
+    // hyphens). Try both so the plugin loads with either integration.
+    for (final framework in const ['mixin_logger', 'mixin-logger']) {
+      try {
+        return DynamicLibrary.open('$framework.framework/$framework');
+      } catch (_) {
+        continue;
+      }
+    }
+    throw UnsupportedError('Failed to load the $_libName dynamic library.');
   }
   if (Platform.isAndroid || Platform.isLinux) {
     return DynamicLibrary.open('lib$_libName.so');

--- a/packages/mixin_logger/pubspec.yaml
+++ b/packages/mixin_logger/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mixin_logger
 resolution: workspace
 description: Simple logger tool for flutter, make it easy to save your app log to file.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/MixinNetwork/flutter-plugins
 
 environment:


### PR DESCRIPTION
Closes #486.

Adds an iOS `Package.swift` for `mixin_logger` so Swift Package Manager projects no longer fall back to CocoaPods and no longer emit:

> The following plugins do not support Swift Package Manager for ios:
>   - mixin_logger

The CocoaPods podspec is left in place, so CocoaPods and SPM both work. Scope is iOS only, matching the issue; macOS is untouched.

### What's included

- **`ios/mixin_logger/Package.swift`** — a dynamic-library SPM package.
- **`ios/mixin_logger/Sources/mixin_logger/mixin_logger.cpp`** — a forwarding source that `#include`s the shared implementation in `src/`, mirroring the existing CocoaPods `Classes/mixin_logger.cpp` forwarder (SPM, like CocoaPods, can't reference sources outside the package directory).
- **`ios/mixin_logger/Sources/mixin_logger/include/mixin_logger/mixin_logger.h`** — a copy of the public header. SPM automatically adds `include/` to the header search path, so the shared source's `#include "mixin_logger/mixin_logger.h"` resolves. This is the SPM equivalent of how CocoaPods' module header map resolves that include to `Classes/mixin_logger.h`.

### FFI / framework-naming note (why there's a Dart change)

`mixin_logger` is an FFI plugin, and the Dart bindings load the native code from a dynamic framework, so the SPM product is built as a dynamic library.

Flutter's generated `FlutterGeneratedPluginSwiftPackage` references plugin products by the package name with underscores replaced by hyphens (`.product(name: "mixin-logger", package: "mixin_logger")`). The product must therefore be named `mixin-logger`, and SPM names the built framework after the product — `mixin-logger.framework/mixin-logger` — whereas CocoaPods produces `mixin_logger.framework/mixin_logger`.

The loader in `lib/src/write_to_file_ffi.dart` previously hardcoded the CocoaPods name, so it now tries both framework names. The existing CocoaPods (and macOS) path is unaffected because `mixin_logger` is still tried first.

### Verification

Built and ran the example on the iOS simulator with SPM enabled (`flutter config --enable-swift-package-manager`, Flutter 3.44.5):

- the SPM warning for iOS is gone and `mixin_logger` no longer appears in the CocoaPods `Podfile.lock`;
- `mixin-logger.framework` is produced with the FFI symbols exported (`nm`: `T _mixin_logger_init`, `T _mixin_logger_write_log`, `T _mixin_logger_set_file_leading`);
- the example app launches without crashing and the FFI logger writes to file (`[I] test` in `log_0.log`);
- `flutter analyze` and `dart format` are clean.

---
https://claude.ai/code/session_01HUSXFyjL8e4u3nQCvynuod
