### PR TITLE
desktop_drop: migrate Android to built-in Kotlin

### DIFF
--- a/packages/desktop_drop/CHANGELOG.md
+++ b/packages/desktop_drop/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.8.0
 
-* [Android] Migrate to built-in Kotlin for Android Gradle Plugin 9 compatibility.
+**BREAKING CHANGE**
+
+* [Android] Migrate to built-in Kotlin. Android host apps must use Android Gradle Plugin 9 or later.
 
 ## 0.7.1
 

--- a/packages/desktop_drop/CHANGELOG.md
+++ b/packages/desktop_drop/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2
+
+* Migrate Android builds to built-in Kotlin for AGP 9 compatibility.
+
 ## 0.7.1
 
 * update worksapce

--- a/packages/desktop_drop/CHANGELOG.md
+++ b/packages/desktop_drop/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.7.2
+## 0.8.0
 
-* Migrate Android builds to built-in Kotlin for AGP 9 compatibility.
+* [Android] Migrate to built-in Kotlin for Android Gradle Plugin 9 compatibility.
 
 ## 0.7.1
 

--- a/packages/desktop_drop/android/build.gradle
+++ b/packages/desktop_drop/android/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 rootProject.allprojects {
     repositories {
@@ -37,16 +36,18 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
     defaultConfig {
         minSdkVersion 16
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }
 

--- a/packages/desktop_drop/example/android/app/build.gradle.kts
+++ b/packages/desktop_drop/example/android/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -13,10 +12,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {
@@ -36,6 +31,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 

--- a/packages/desktop_drop/example/android/gradle.properties
+++ b/packages/desktop_drop/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# Enable AGP 9 built-in Kotlin for this example.
+android.builtInKotlin=true
+# Keep Flutter's current legacy AGP DSL compatibility while it migrates.
+android.newDsl=false

--- a/packages/desktop_drop/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/desktop_drop/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/packages/desktop_drop/example/android/settings.gradle.kts
+++ b/packages/desktop_drop/example/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("com.android.application") version "9.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")

--- a/packages/desktop_drop/example/lib/main.dart
+++ b/packages/desktop_drop/example/lib/main.dart
@@ -33,10 +33,11 @@ class MyApp extends StatelessWidget {
         bool grantedPermission = await DesktopDrop.instance
             .startAccessingSecurityScopedResource(bookmark: appleBookmark);
 
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-            content: Text(
-          "file permission :" + grantedPermission.toString(),
-        )));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text("file permission :" + grantedPermission.toString()),
+          ),
+        );
       }
 
       var file = File(path);
@@ -45,12 +46,14 @@ class MyApp extends StatelessWidget {
       var fileSize = contents.length;
 
       if (bookmarkEnable) {
-        await DesktopDrop.instance
-            .stopAccessingSecurityScopedResource(bookmark: appleBookmark);
+        await DesktopDrop.instance.stopAccessingSecurityScopedResource(
+          bookmark: appleBookmark,
+        );
       }
 
-      final snackBar =
-          SnackBar(content: Text('file size:' + fileSize.toString()));
+      final snackBar = SnackBar(
+        content: Text('file size:' + fileSize.toString()),
+      );
       ScaffoldMessenger.of(context).showSnackBar(snackBar);
     } catch (e) {
       final snackBar = SnackBar(content: Text('error:' + e.toString()));
@@ -62,9 +65,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
+        appBar: AppBar(title: const Text('Plugin example app')),
         body: Wrap(
           direction: Axis.horizontal,
           runSpacing: 8,
@@ -77,33 +78,31 @@ class MyApp extends StatelessWidget {
             const ExampleDragTarget(),
             const ExampleDragTarget(),
             if (UniversalPlatform.isMacOS)
-              StatefulBuilder(builder: (context, setState) {
-                return Column(
-                  children: [
-                    const Text(
-                      "Test Apple Bookmark\n1 drag file \n2 save the bookmark,\n3 restart app\n4 choice test button",
-                    ),
-                    TextButton(
-                      onPressed: () async {
-                        loadFile(context, true);
-                        return;
-                      },
-                      child: const Text(
-                        "with applemark, suc",
+              StatefulBuilder(
+                builder: (context, setState) {
+                  return Column(
+                    children: [
+                      const Text(
+                        "Test Apple Bookmark\n1 drag file \n2 save the bookmark,\n3 restart app\n4 choice test button",
                       ),
-                    ),
-                    TextButton(
-                      onPressed: () async {
-                        loadFile(context, false);
-                        return;
-                      },
-                      child: const Text(
-                        "without applemark, err",
+                      TextButton(
+                        onPressed: () async {
+                          loadFile(context, true);
+                          return;
+                        },
+                        child: const Text("with applemark, suc"),
                       ),
-                    ),
-                  ],
-                );
-              }),
+                      TextButton(
+                        onPressed: () async {
+                          loadFile(context, false);
+                          return;
+                        },
+                        child: const Text("without applemark, err"),
+                      ),
+                    ],
+                  );
+                },
+              ),
           ],
         ),
       ),
@@ -129,11 +128,13 @@ class _ExampleDragTargetState extends State<ExampleDragTarget> {
   Future<void> printFiles(List<DropItem> files, [int depth = 0]) async {
     debugPrint('  |' * depth);
     for (final file in files) {
-      debugPrint('  |' * depth +
-          '> ${file.path} ${file.name}'
-              '  ${await file.lastModified()}'
-              '  ${await file.length()}'
-              '  ${file.mimeType}');
+      debugPrint(
+        '  |' * depth +
+            '> ${file.path} ${file.name}'
+                '  ${await file.lastModified()}'
+                '  ${await file.length()}'
+                '  ${file.mimeType}',
+      );
       if (file is DropItemDirectory) {
         printFiles(file.children, depth + 1);
       }
@@ -195,8 +196,9 @@ class _ExampleDragTargetState extends State<ExampleDragTarget> {
                     Map<String, String> data = {};
                     data["path"] = dropFiles[0].path;
 
-                    String bookmark =
-                        base64.encode(dropFiles[0].extraAppleBookmark!);
+                    String bookmark = base64.encode(
+                      dropFiles[0].extraAppleBookmark!,
+                    );
                     data["apple-bookmark"] = bookmark;
 
                     String jsonStr = json.encode(data);
@@ -205,16 +207,20 @@ class _ExampleDragTargetState extends State<ExampleDragTarget> {
                         await SharedPreferences.getInstance();
                     prefs.setString("apple-bookmark", jsonStr);
 
-                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
                         content: Text(
-                            'Save Suc, restart app, and Test Apple Bookmark')));
+                          'Save Suc, restart app, and Test Apple Bookmark',
+                        ),
+                      ),
+                    );
                   },
                   child: const Text(
                     'save bookmark',
                     style: TextStyle(fontSize: 14),
                   ),
                 ),
-              )
+              ),
           ],
         ),
       ),

--- a/packages/desktop_drop/example/pubspec.lock
+++ b/packages/desktop_drop/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.1"
+    version: "0.8.0"
   fake_async:
     dependency: transitive
     description:
@@ -224,13 +224,13 @@ packages:
     source: hosted
     version: "2.5.2"
   shared_preferences_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences_android
-      sha256: a768fc8ede5f0c8e6150476e14f38e2417c0864ca36bb4582be8e21925a03c22
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -365,5 +365,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/packages/desktop_drop/example/pubspec.yaml
+++ b/packages/desktop_drop/example/pubspec.yaml
@@ -7,8 +7,8 @@ publish_to: 'none'
 #   sdk: ">=2.12.0 <3.0.0"
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
-  flutter: ">=1.20.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
@@ -19,6 +19,7 @@ dependencies:
   cross_file: ^0.3.2
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.2.3 
+  shared_preferences_android: ^2.4.27
   universal_platform:
 
 dev_dependencies:

--- a/packages/desktop_drop/pubspec.yaml
+++ b/packages/desktop_drop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: desktop_drop
 resolution: workspace
 description: A plugin which allows user dragging files to your flutter desktop applications.
-version: 0.7.2
+version: 0.8.0
 homepage: https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_drop
 
 environment:

--- a/packages/desktop_drop/pubspec.yaml
+++ b/packages/desktop_drop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: desktop_drop
 resolution: workspace
 description: A plugin which allows user dragging files to your flutter desktop applications.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_drop
 
 environment:


### PR DESCRIPTION
## Summary
- remove the legacy `kotlin-android` plugin application from `desktop_drop`
- configure Kotlin compilation through AGP built-in Kotlin
- migrate the Android example to AGP 9.1 and Gradle 9.3.1
- upgrade the example Android preferences implementation for AGP 9 compatibility
- bump `desktop_drop` to 0.8.0

Fixes #490

## Testing
- `flutter test`
- `flutter analyze`
- `cd packages/desktop_drop/example/android && ./gradlew :app:assembleDebug --no-daemon`