### PR TITLE
pasteboard: add await for clipboard reads inside try blocks

### DIFF
--- a/packages/pasteboard/lib/src/pasteboard_platform_web.dart
+++ b/packages/pasteboard/lib/src/pasteboard_platform_web.dart
@@ -40,7 +40,7 @@ class PasteboardPlatformWeb implements PasteboardPlatform {
       for (var clipboardItem in clipboardItems.toDart) {
         if (clipboardItem.types.toDart.contains('text/html'.toJS)) {
           final blob = await clipboardItem.getType('text/html').toDart;
-          return _readBlobAsText(blob);
+          return await _readBlobAsText(blob);
         }
       }
     } catch (e) {
@@ -57,7 +57,7 @@ class PasteboardPlatformWeb implements PasteboardPlatform {
         for (var type in item.types.toDart) {
           if (type.toDart.startsWith('image/')) {
             final blob = await item.getType(type.toDart).toDart;
-            return blob._readAsUint8List();
+            return await blob._readAsUint8List();
           }
         }
       }


### PR DESCRIPTION
Fixes the failing `dart analyze` step of the "Validate Workspace" CI job on main.

`pasteboard_platform_web.dart` returned Futures without awaiting them inside try blocks (`unawaited_return_in_try_block`, 2 warnings). A Future returned this way can fail *after* the function has exited the try scope, so the surrounding `catch` never runs and the error escapes unhandled.

Adding `await` routes those failures through the existing catch handlers, which already return `null` / log — matching the original intent.

- `html`: `return _readBlobAsText(blob)` → `return await _readBlobAsText(blob)`
- `image`: `return blob._readAsUint8List()` → `return await blob._readAsUint8List()`

Verified locally: `dart analyze` clean in lib/, `dart format --set-exit-if-changed` reports no changes.