### PR TITLE
desktop_drop: restore Android compatibility with AGP < 9 hosts

### DIFF
--- a/packages/desktop_drop/CHANGELOG.md
+++ b/packages/desktop_drop/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.2
+
+* [desktop_drop] [Android] restore compatibility with hosts on Android Gradle Plugin < 9 by applying the Kotlin Gradle Plugin conditionally, per the Flutter built-in Kotlin migration guide
+* [desktop_drop] [Android] bump bundled Kotlin Gradle Plugin to 2.2.0 to support the `kotlin.compilerOptions` DSL on AGP < 9 hosts
+
 ## 0.8.1
 
 * [desktop_drop] [Linux] register the `application/vnd.portal.filetransfer` drag target and deliver its key via a new `performOperation_portal` channel message

--- a/packages/desktop_drop/android/build.gradle
+++ b/packages/desktop_drop/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.example.desktop_drop'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.25'
+    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()
@@ -15,6 +15,16 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+
+// Apply KGP only when the host does not provide built-in Kotlin.
+// AGP 9+ ships Kotlin built-in and hard-fails if kotlin-android is applied,
+// while hosts on AGP < 9 do not apply any Kotlin plugin to this subproject.
+// See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+// ("Support Flutter versions earlier than 3.44").
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 rootProject.allprojects {
     repositories {

--- a/packages/desktop_drop/pubspec.yaml
+++ b/packages/desktop_drop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: desktop_drop
 resolution: workspace
 description: A plugin which allows user dragging files to your flutter desktop applications.
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_drop
 
 environment:


### PR DESCRIPTION
## Problem

desktop_drop 0.8.1 failed at configuration time on every app using AGP < 9 (localsend for example) with:

    Build file '.../desktop_drop-0.8.1/android/build.gradle' line: 48
    * What went wrong:
    A problem occurred evaluating project ':desktop_drop'.
    > Could not find method kotlin() for arguments [...] on project ':desktop_drop'

This affects all apps below Flutter 3.44 — they cannot simply move to AGP 9,
because Flutter itself only supports AGP 9 from 3.44+
([built-in Kotlin migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin)).
For those apps, the 0.8.0 changelog note ("must use AGP 9 or later") is unsatisfiable.

## Root cause

`android/build.gradle` calls `kotlin { compilerOptions {} }` but never applies KGP:

| Host    | Who compiles Kotlin?                  | Unconditional `kotlin{}` | Conditional apply              |
|---------|---------------------------------------|--------------------------|--------------------------------|
| AGP < 9 | nobody → plugin must apply KGP itself | ❌ `kotlin()` not found  | ✅ applies KGP itself          |
| AGP ≥ 9 | AGP built-in Kotlin                   | ✅ works                 | ✅ skips — hard error if applied |

The example app (AGP 9.1) only ever exercised the second row, which is why this went
unnoticed. An alternative fix — raising the plugin's minimum to Flutter 3.44 — would
lock out apps on older stable versions; the conditional keeps every host working.

## Fix

Implements the official guide section
["Support Flutter versions earlier than 3.44"](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors):

- apply `kotlin-android` only when host AGP major < 9
- bump bundled KGP `1.9.25` → `2.2.0`, since the `kotlin.compilerOptions {}` DSL requires KGP ≥ 2.0

No Dart or Kotlin changes.

## Verification

- **AGP < 9 host**: real app (LocalSend) builds its debug APK green on
  Flutter 3.41.9 · AGP 8.12.1 · Gradle 8.13 against this branch :
  [run](https://github.com/loucass/localsend/actions/runs/32880416440)
  (`✓ Built app-debug.apk`; without the patch this same build fails at
  configuration time, before any compilation starts)
- **AGP ≥ 9 host**: example app builds green on AGP 9.1 · Gradle 9.3.1 · Flutter 3.47.1 :
  [run](https://github.com/loucass/flutter-plugins/actions/runs/32879589559)

Could you tag a `desktop_drop v0.8.2` after merge so downstream apps can pick this up? Thanks!