### PR TITLE
fix Android compatibility with AGP > 9 hosts in desktop_drop

### DIFF
--- a/packages/desktop_drop/CHANGELOG.md
+++ b/packages/desktop_drop/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.3
+
+* [Android] Fix `Could not find method kotlin()` / `kotlinOptions()` on Gradle 9 / AGP 9 hosts by making the Kotlin configuration block itself conditional on the host AGP, complementing the conditional `apply plugin` from 0.8.2
+
 ## 0.8.2
 
 * [Android] Restore compatibility with Android Gradle Plugin versions below 9 by applying the Kotlin Gradle Plugin conditionally, while continuing to use built-in Kotlin on AGP 9 and later [#495](https://github.com/MixinNetwork/flutter-plugins/pull/495)

--- a/packages/desktop_drop/android/build.gradle
+++ b/packages/desktop_drop/android/build.gradle
@@ -16,14 +16,28 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-// Apply KGP only when the host does not provide built-in Kotlin.
-// AGP 9+ ships Kotlin built-in and hard-fails if kotlin-android is applied,
-// while hosts on AGP < 9 do not apply any Kotlin plugin to this subproject.
-// See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
-// ("Support Flutter versions earlier than 3.44").
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+// AGP 9 has built-in Kotlin; applying KGP there fails.
+// Hosts on AGP < 9 don't provide Kotlin for this plugin, so we apply it.
+// Each AGP uses a different DSL for jvmTarget.
+def agpMajor = 0
+try {
+    agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+} catch (ignored) {
+    agpMajor = 0
+}
 if (agpMajor < 9) {
     apply plugin: 'kotlin-android'
+    android {
+        kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_1_8.toString()
+        }
+    }
+} else {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        }
+    }
 }
 
 rootProject.allprojects {
@@ -52,12 +66,6 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-    }
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }
 

--- a/packages/desktop_drop/pubspec.yaml
+++ b/packages/desktop_drop/pubspec.yaml
@@ -1,7 +1,7 @@
 name: desktop_drop
 resolution: workspace
 description: A plugin which allows user dragging files to your flutter desktop applications.
-version: 0.8.2
+version: 0.8.3
 homepage: https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_drop
 
 environment:


### PR DESCRIPTION
Follow-up to #495 — @ekuleshov reported that `0.8.2` (Gradle 9.1.0 + Flutter 3.44.8) still fails with the same `Could not find method kotlin()` error that #495 was meant to fix.

## Problem

`0.8.2` made the `apply plugin: 'kotlin-android'` line conditional on AGP major `< 9`, but left the Kotlin configuration block unconditional:

* `android { kotlinOptions { jvmTarget } }` — the pre-AGP-9 form, removed in AGP 9

Result: AGP 8 hosts now passed, but AGP 9.1 hosts failed on the `kotlin {}` DSL itself (`kotlin()` not found when KGP wasn't applied).

## Root cause

| Host    | Who compiles Kotlin?                  | `kotlin {}` unconditional | Conditional (this PR) |
|---------|---------------------------------------|---------------------------|-----------------------|
| AGP < 9 | nobody → plugin must apply KGP itself | ❌ `kotlin()` not found*  | ✅ `android.kotlinOptions` branch |
| AGP ≥ 9 | AGP built-in Kotlin                   | ✅ works                  | ✅ `kotlin.compilerOptions` branch |

*`kotlin` extension only exists after KGP is applied.

## Fix

Make the **configuration block itself** conditional:

```groovy
def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
if (agpMajor < 9) {
    apply plugin: 'kotlin-android'
    android {
        kotlinOptions {
            jvmTarget = JavaVersion.VERSION_1_8.toString()
        }
    }
} else {
    kotlin {
        compilerOptions {
            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
        }
    }
}
```

## Verification

* **AGP < 9 host**: LocalSend debug APK on Flutter 3.41.9 · AGP 8.12.1 · Gradle 8.13 — [run](https://github.com/loucass/localsend/actions/runs/33248645316) (`✓ Built app-debug.apk`)
* **AGP 9 host**: `desktop_drop` example on AGP 9.1 · Gradle 9.3.1 · Flutter 3.47.1 — [run](https://github.com/loucass/flutter-plugins/actions/runs/33248620672)