### PR TITLE
ci: add Android build for desktop_drop

### DIFF
--- a/.github/workflows/desktop_drop_android.yml
+++ b/.github/workflows/desktop_drop_android.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Downgrade AGP to 8.12.1 for compatibility check
         run: |
           sed -i 's/id("com.android.application") version "9.1.0"/id("com.android.application") version "8.12.1"/' packages/desktop_drop/example/android/settings.gradle.kts
-          sed -i 's|gradle-9.3.1-all.zip|gradle-8.13-all.zip|' packages/desktop_drop/example/android/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's|gradle-9.3.1-all.zip|gradle-8.14.3-all.zip|' packages/desktop_drop/example/android/gradle/wrapper/gradle-wrapper.properties
           cat packages/desktop_drop/example/android/settings.gradle.kts | grep com.android.application
           cat packages/desktop_drop/example/android/gradle/wrapper/gradle-wrapper.properties | grep distributionUrl
 

--- a/.github/workflows/desktop_drop_android.yml
+++ b/.github/workflows/desktop_drop_android.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.47.1"
           cache: true
 
       - name: Downgrade AGP to 8.12.1 for compatibility check

--- a/.github/workflows/desktop_drop_android.yml
+++ b/.github/workflows/desktop_drop_android.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/desktop_drop_android.yml"
 
 jobs:
-  build:
+  build-agp9:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -21,6 +21,34 @@ jobs:
         with:
           flutter-version: "3.47.1"
           cache: true
+
+      - run: flutter pub get
+        working-directory: packages/desktop_drop/example
+
+      - run: flutter build apk --debug
+        working-directory: packages/desktop_drop/example
+
+  build-agp8:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.9"
+          cache: true
+
+      - name: Downgrade AGP to 8.12.1 for compatibility check
+        run: |
+          sed -i 's/id("com.android.application") version "9.1.0"/id("com.android.application") version "8.12.1"/' packages/desktop_drop/example/android/settings.gradle.kts
+          sed -i 's|gradle-9.3.1-all.zip|gradle-8.13-all.zip|' packages/desktop_drop/example/android/gradle/wrapper/gradle-wrapper.properties
+          cat packages/desktop_drop/example/android/settings.gradle.kts | grep com.android.application
+          cat packages/desktop_drop/example/android/gradle/wrapper/gradle-wrapper.properties | grep distributionUrl
 
       - run: flutter pub get
         working-directory: packages/desktop_drop/example

--- a/.github/workflows/desktop_drop_android.yml
+++ b/.github/workflows/desktop_drop_android.yml
@@ -1,0 +1,29 @@
+name: desktop_drop Android
+
+on:
+  pull_request:
+    paths:
+      - "packages/desktop_drop/**"
+      - ".github/workflows/desktop_drop_android.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.47.1"
+          cache: true
+
+      - run: flutter pub get
+        working-directory: packages/desktop_drop/example
+
+      - run: flutter build apk --debug
+        working-directory: packages/desktop_drop/example


### PR DESCRIPTION
desktop_drop had no Android CI, so the AGP 9 regression in 0.8.1 shipped unnoticed.

This adds a path-filtered job that builds the example APK (AGP 9.1) only when desktop_drop changes.

Follow-up to #495 and #498 — would have caught both the `kotlin()` and `kotlinOptions()` failures before merge.